### PR TITLE
gloss-examples.cabal: fix typo in 'Build-depends:' field

### DIFF
--- a/gloss-examples/gloss-examples.cabal
+++ b/gloss-examples/gloss-examples.cabal
@@ -281,7 +281,7 @@ Executable gloss-fluid
         
 
 Executable gloss-snow
-  Build-depends
+  Build-depends:
         base            == 4.7.*,
         repa            == 3.2.*,
         gloss           == 1.8.2.*
@@ -296,7 +296,7 @@ Executable gloss-snow
 
 
 Executable gloss-mandel
-  Build-depends
+  Build-depends:
         base            == 4.7.*,
         repa            == 3.2.*,
         gloss           == 1.8.2.*
@@ -314,7 +314,7 @@ Executable gloss-mandel
 
 
 Executable gloss-graph
-  Build-depends
+  Build-depends:
         base            == 4.7.*,
         containers      == 0.5.*,
         gloss           == 1.8.2.*


### PR DESCRIPTION
Noticed by Cabal:

> Warning: gloss-examples.cabal: Unexpected section 'build-depends' on line 284
> Warning: gloss-examples.cabal: Unexpected section 'build-depends' on line 299
> Warning: gloss-examples.cabal: Unexpected section 'build-depends' on line 317

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
