### PR TITLE
expose the opaque type State

### DIFF
--- a/gloss-rendering/Graphics/Gloss/Rendering.hs
+++ b/gloss-rendering/Graphics/Gloss/Rendering.hs
@@ -25,7 +25,8 @@ module Graphics.Gloss.Rendering
         , renderPicture
         , withModelview
         , withClearBuffer
-        , RS.initState)
+        , RS.initState
+        , RS.State)
 
 where
 import Graphics.Gloss.Internals.Rendering.Common


### PR DESCRIPTION
The user is given values of this type, they need to be able to spell out the type in their type signatures.

See, for example, [this gist](https://gist.github.com/gelisam/27bf515548a9ce551a18) in which I wanted to give type signatures to my helper functions but couldn't.