### PR TITLE
Bumping dependencies for GHC 7.10

### DIFF
--- a/gloss-algorithms/gloss-algorithms.cabal
+++ b/gloss-algorithms/gloss-algorithms.cabal
@@ -22,7 +22,7 @@ source-repository head
 
 Library
   Build-Depends: 
-        base       == 4.7.*,
+        base       >= 4.7 && <4.9,
         ghc-prim   == 0.3.*,
         containers == 0.5.*,
         gloss      == 1.9.2.*

--- a/gloss-examples/gloss-examples.cabal
+++ b/gloss-examples/gloss-examples.cabal
@@ -23,7 +23,7 @@ source-repository head
 
 Executable gloss-bitmap
   Build-depends:
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         bytestring      == 0.10.*,
         bmp             == 1.2.*,
         gloss           == 1.9.2.*
@@ -34,7 +34,7 @@ Executable gloss-bitmap
 
 Executable gloss-boids
   Build-depends:
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         gloss           == 1.9.2.*
   Main-is:        Main.hs
   other-modules:  KDTree2d Vec2
@@ -44,7 +44,7 @@ Executable gloss-boids
 
 Executable gloss-clock
   Build-depends: 
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         gloss           == 1.9.2.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Clock
@@ -53,7 +53,7 @@ Executable gloss-clock
 
 Executable gloss-conway
   Build-depends: 
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         vector          == 0.10.*,
         gloss           == 1.9.2.*
   Main-is:        Main.hs
@@ -64,7 +64,7 @@ Executable gloss-conway
 
 Executable gloss-draw
   Build-depends:
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         gloss           == 1.9.2.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Draw
@@ -73,7 +73,7 @@ Executable gloss-draw
 
 Executable gloss-easy
   Build-depends:
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         gloss           == 1.9.2.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Easy
@@ -82,7 +82,7 @@ Executable gloss-easy
 
 Executable gloss-eden
   Build-depends: 
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         random          == 1.1.*,
         gloss           == 1.9.2.*
   Main-is:        Main.hs
@@ -93,7 +93,7 @@ Executable gloss-eden
 
 Executable gloss-flake
   Build-depends:
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         gloss           == 1.9.2.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Flake
@@ -102,7 +102,7 @@ Executable gloss-flake
 
 Executable gloss-gameevent
   Build-depends: 
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         gloss           == 1.9.2.*
   Main-is:        Main.hs
   hs-source-dirs: picture/GameEvent
@@ -111,7 +111,7 @@ Executable gloss-gameevent
 
 Executable gloss-hello
   Build-depends: 
-        base            == 4.7.*, 
+        base >= 4.7 && < 4.9, 
         gloss           == 1.9.2.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Hello
@@ -120,7 +120,7 @@ Executable gloss-hello
 
 Executable gloss-lifespan
   Build-depends: 
-        base            == 4.7.*, 
+        base >= 4.7 && < 4.9, 
         gloss           == 1.9.2.*,
         random          == 1.1.*
   Main-is:        Main.hs
@@ -131,7 +131,7 @@ Executable gloss-lifespan
 
 Executable gloss-machina
   Build-depends: 
-        base            == 4.7.*, 
+        base >= 4.7 && < 4.9, 
         gloss           == 1.9.2.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Machina
@@ -140,7 +140,7 @@ Executable gloss-machina
 
 Executable gloss-occlusion
   Build-depends: 
-        base             == 4.7.*, 
+        base >= 4.7 && < 4.9, 
         gloss            == 1.9.2.*,
         gloss-algorithms == 1.9.2.*
   Main-is: Main.hs
@@ -151,7 +151,7 @@ Executable gloss-occlusion
 
 Executable gloss-styrene
   Build-depends: 
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         ghc-prim        == 0.3.*,
         containers      == 0.5.*,
         gloss           == 1.9.2.*
@@ -163,7 +163,7 @@ Executable gloss-styrene
 
 Executable gloss-tree
   Build-depends: 
-        base            == 4.7.*, 
+        base >= 4.7 && < 4.9, 
         gloss           == 1.9.2.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Tree
@@ -172,7 +172,7 @@ Executable gloss-tree
 
 Executable gloss-visibility
   Build-depends: 
-        base            == 4.7.*, 
+        base >= 4.7 && < 4.9, 
         vector          == 0.10.*,
         gloss           == 1.9.2.*
   Main-is:        Main.hs
@@ -183,7 +183,7 @@ Executable gloss-visibility
 
 Executable gloss-zen
   Build-depends: 
-        base            == 4.7.*, 
+        base >= 4.7 && < 4.9, 
         gloss           == 1.9.2.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Zen
@@ -192,7 +192,7 @@ Executable gloss-zen
 
 Executable gloss-crystal
   Build-depends:
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         gloss           == 1.9.2.*,
         gloss-raster    == 1.9.2.*
   Main-is:        Main.hs
@@ -210,7 +210,7 @@ Executable gloss-crystal
 
 Executable gloss-ray
   Build-depends:
-        base           == 4.7.*,
+        base >= 4.7 && < 4.9,
         gloss          == 1.9.2.*,
         gloss-raster   == 1.9.2.*
   Main-is:        Main.hs
@@ -226,7 +226,7 @@ Executable gloss-ray
 
 Executable gloss-pulse
   Build-depends:
-        base           == 4.7.*,
+        base >= 4.7 && < 4.9,
         gloss          == 1.9.2.*,
         gloss-raster   == 1.9.2.*
   Main-is:        Main.hs
@@ -241,7 +241,7 @@ Executable gloss-pulse
 
 Executable gloss-wave
   Build-depends:
-        base           == 4.7.*,
+        base >= 4.7 && < 4.9,
         ghc-prim       == 0.3.*,
         vector         == 0.10.*,
         gloss          == 1.9.2.*,
@@ -257,7 +257,7 @@ Executable gloss-wave
 
 Executable gloss-fluid
   Build-depends:
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         ghc-prim        == 0.3.*,
         vector          == 0.10.*,
         repa            == 3.3.*,
@@ -283,7 +283,7 @@ Executable gloss-fluid
 
 Executable gloss-snow
   Build-depends:
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         repa            == 3.3.*,
         gloss           == 1.9.2.*
   Main-is:      Main.hs
@@ -298,7 +298,7 @@ Executable gloss-snow
 
 Executable gloss-mandel
   Build-depends:
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         repa            == 3.3.*,
         gloss           == 1.9.2.*
   Main-is:        Main.hs
@@ -316,7 +316,7 @@ Executable gloss-mandel
 
 Executable gloss-graph
   Build-depends:
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         containers      == 0.5.*,
         gloss           == 1.9.2.*
   Main-is:        Main.hs
@@ -327,7 +327,7 @@ Executable gloss-graph
 
 Executable gloss-render
   Build-depends:
-        base            == 4.7.*,
+        base >= 4.7 && < 4.9,
         containers      == 0.5.*,
         gloss           == 1.9.2.*,
         gloss-rendering == 1.9.2.*,

--- a/gloss-raster/gloss-raster.cabal
+++ b/gloss-raster/gloss-raster.cabal
@@ -22,7 +22,7 @@ source-repository head
 
 Library
   Build-Depends: 
-        base       == 4.7.*,
+        base       >= 4.7 && <4.9,
         ghc-prim   == 0.3.*,
         containers == 0.5.*,
         repa       == 3.3.*,

--- a/gloss-rendering/gloss-rendering.cabal
+++ b/gloss-rendering/gloss-rendering.cabal
@@ -28,11 +28,11 @@ library
         Graphics.Gloss.Internals.Rendering.State
 
   build-depends:       
-        base       == 4.7.*,
+        base       >= 4.7 && <4.9,
         containers == 0.5.*,
         bytestring == 0.10.*,
-        OpenGL     == 2.9.*,
-        GLUT       == 2.5.*,
+        OpenGL     >= 2.9 && <2.11,
+        GLUT       >= 2.5 && <2.7,
         bmp        == 1.2.*
 
   ghc-options:

--- a/gloss/gloss.cabal
+++ b/gloss/gloss.cabal
@@ -37,12 +37,12 @@ Flag ExplicitBackend
 
 Library
   Build-Depends: 
-        base       == 4.7.*,
+        base       >= 4.7 && < 4.9,
         ghc-prim   == 0.3.*,
         containers == 0.5.*,
         bytestring == 0.10.*,
-        OpenGL     == 2.9.*,
-        GLUT       == 2.5.*,
+        OpenGL     >= 2.9 && < 2.11,
+        GLUT       >= 2.5 && < 2.7,
         bmp        == 1.2.*,
         gloss-rendering == 1.9.2.*
 


### PR DESCRIPTION
I've successfully built gloss-rendering & gloss with GHC7.10 RC2 on windows. I wasn't able to build gloss-algorithm due to a dependence on REPA which also posses strict base bounds.