### PR TITLE
Rendering a Bitmap was making everything white

### DIFF
--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
@@ -180,6 +180,7 @@ drawPicture state circScale picture
 		GL.textureBinding GL.Texture2D $= Just (texObject tex)
 		
 		-- Set to opaque
+                oldColor <- get GL.currentColor
 		GL.currentColor $= GL.Color4 1.0 1.0 1.0 1.0
 		
 		-- Draw textured polygon
@@ -191,7 +192,10 @@ drawPicture state circScale picture
 
 			(bitmapPath (fromIntegral width) (fromIntegral height))
 			        [(0,0), (1.0,0), (1.0,1.0), (0,1.0)]
-
+		
+		-- Restore color
+		GL.currentColor $= oldColor
+		
 		-- Disable texturing
 		GL.texture GL.Texture2D $= GL.Disabled
 


### PR DESCRIPTION
The code was changing the color to RGBA 1 1 1 1 make sure the current
color was opaque, but didn't change it back to the previous color,
thereby causing every subsequent Picture without an explicit color call
to be drawn in white.