### PR TITLE
Remove dead code

### DIFF
--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
@@ -93,7 +93,6 @@ drawPicture state circScale picture
 
 	-- colors with float components.
 	Color col p
-	 |  stateColor state
 	 ->  do	oldColor 	 <- get GL.currentColor
 
 		let RGBA r g b a  = col
@@ -101,9 +100,6 @@ drawPicture state circScale picture
 		GL.currentColor	 $= GL.Color4 (gf r) (gf g) (gf b) (gf a)
 		drawPicture state circScale p
 		GL.currentColor	 $= oldColor		
-
-	 |  otherwise
-	 -> 	drawPicture state circScale p
 
 
         -- Translation --------------------------

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
@@ -33,8 +33,8 @@ renderPicture
 
 renderPicture state circScale picture
  = do   
-        -- Setup render state for world
-	setLineSmooth	(stateLineSmooth state)
+        -- | Turn line smoothing off
+	GL.lineSmooth $= GL.Disabled
 
         -- Turn alpha blending on
  	GL.blend	$= GL.Enabled
@@ -320,13 +320,6 @@ freeTexture tex
 
 
 -- Utils ----------------------------------------------------------------------
--- | Turn line smoothing on or off
-setLineSmooth :: Bool -> IO ()
-setLineSmooth state
-	| state		= GL.lineSmooth	$= GL.Enabled
-	| otherwise	= GL.lineSmooth $= GL.Disabled
-
-
 vertexPFs ::	[(Float, Float)] -> IO ()
 {-# INLINE vertexPFs #-}
 vertexPFs []	= return ()

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
@@ -35,8 +35,11 @@ renderPicture state circScale picture
  = do   
         -- Setup render state for world
 	setLineSmooth	(stateLineSmooth state)
-	setBlendAlpha	(stateBlendAlpha state)
-	
+
+        -- Turn alpha blending on
+ 	GL.blend	$= GL.Enabled
+	GL.blendFunc	$= (GL.SrcAlpha, GL.OneMinusSrcAlpha)
+
 	-- Draw the picture
         checkErrors "before drawPicture."
         drawPicture state circScale picture
@@ -317,17 +320,6 @@ freeTexture tex
 
 
 -- Utils ----------------------------------------------------------------------
--- | Turn alpha blending on or off
-setBlendAlpha :: Bool -> IO ()
-setBlendAlpha state
- 	| state	
- 	= do	GL.blend	$= GL.Enabled
-		GL.blendFunc	$= (GL.SrcAlpha, GL.OneMinusSrcAlpha)
-
-	| otherwise
- 	= do	GL.blend	$= GL.Disabled
-		GL.blendFunc	$= (GL.One, GL.Zero) 	
-
 -- | Turn line smoothing on or off
 setLineSmooth :: Bool -> IO ()
 setLineSmooth state

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
@@ -60,11 +60,6 @@ drawPicture state circScale picture
 
 	-- polygon (where?)
 	Polygon path
-	 | stateWireframe state
-	 -> GL.renderPrimitive GL.LineLoop
-	 	$ vertexPFs path
-		
-	 | otherwise
 	 -> GL.renderPrimitive GL.Polygon
 	 	$ vertexPFs path
 

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/State.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/State.hs
@@ -17,11 +17,8 @@ import qualified Graphics.Rendering.OpenGL.GL   as GL
 -- | Render options settings
 data State
 	= State
-	{ -- | Whether to use line smoothing
-	  stateLineSmooth	:: !Bool
-	
-	-- | Cache of Textures that we've sent to OpenGL.
-	, stateTextures         :: !(IORef [Texture])
+	{ -- | Cache of Textures that we've sent to OpenGL.
+	  stateTextures         :: !(IORef [Texture])
 	}
 	
 
@@ -54,7 +51,6 @@ initState :: IO State
 initState
  = do   textures        <- newIORef []
 	return  State
-	        { stateLineSmooth	= False 
-	        , stateTextures         = textures }
+	        { stateTextures         = textures }
 	
 

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/State.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/State.hs
@@ -17,11 +17,8 @@ import qualified Graphics.Rendering.OpenGL.GL   as GL
 -- | Render options settings
 data State
 	= State
-	{ -- | Whether to use color
-	  stateColor		:: !Bool
-
-	-- | Whether to force wireframe mode only
-	, stateWireframe	:: !Bool
+	{ -- | Whether to force wireframe mode only
+	  stateWireframe	:: !Bool
 
 	-- | Whether to use alpha blending
 	, stateBlendAlpha	:: !Bool
@@ -63,8 +60,7 @@ initState :: IO State
 initState
  = do   textures        <- newIORef []
 	return  State
-	        { stateColor		= True
-                , stateWireframe	= False
+	        { stateWireframe	= False
 	        , stateBlendAlpha	= True
 	        , stateLineSmooth	= False 
 	        , stateTextures         = textures }

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/State.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/State.hs
@@ -17,11 +17,8 @@ import qualified Graphics.Rendering.OpenGL.GL   as GL
 -- | Render options settings
 data State
 	= State
-	{ -- | Whether to use alpha blending
-	  stateBlendAlpha	:: !Bool
-
-	-- | Whether to use line smoothing
-	, stateLineSmooth	:: !Bool
+	{ -- | Whether to use line smoothing
+	  stateLineSmooth	:: !Bool
 	
 	-- | Cache of Textures that we've sent to OpenGL.
 	, stateTextures         :: !(IORef [Texture])
@@ -57,8 +54,7 @@ initState :: IO State
 initState
  = do   textures        <- newIORef []
 	return  State
-	        { stateBlendAlpha	= True
-	        , stateLineSmooth	= False 
+	        { stateLineSmooth	= False 
 	        , stateTextures         = textures }
 	
 

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/State.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/State.hs
@@ -17,11 +17,8 @@ import qualified Graphics.Rendering.OpenGL.GL   as GL
 -- | Render options settings
 data State
 	= State
-	{ -- | Whether to force wireframe mode only
-	  stateWireframe	:: !Bool
-
-	-- | Whether to use alpha blending
-	, stateBlendAlpha	:: !Bool
+	{ -- | Whether to use alpha blending
+	  stateBlendAlpha	:: !Bool
 
 	-- | Whether to use line smoothing
 	, stateLineSmooth	:: !Bool
@@ -60,8 +57,7 @@ initState :: IO State
 initState
  = do   textures        <- newIORef []
 	return  State
-	        { stateWireframe	= False
-	        , stateBlendAlpha	= True
+	        { stateBlendAlpha	= True
 	        , stateLineSmooth	= False 
 	        , stateTextures         = textures }
 	

--- a/gloss-rendering/Graphics/Gloss/Rendering.hs
+++ b/gloss-rendering/Graphics/Gloss/Rendering.hs
@@ -25,7 +25,8 @@ module Graphics.Gloss.Rendering
         , renderPicture
         , withModelview
         , withClearBuffer
-        , RS.initState)
+        , RS.initState
+        , RS.State)
 
 where
 import Graphics.Gloss.Internals.Rendering.Common


### PR DESCRIPTION
Most of the fields in Rendering.State was dead code, so I removed it.

After removing all the dead code, all that remained of `State` was a record with a single field, the texture cache. So I replaced the record with that texture cache, and I replaced the `state` variables with `cachedTexture` everywhere, including in the comments. I haven't touched the many other types which are also called `State`.