### PR TITLE
Add a 'BitmapFormat' to allow alt channel orders, row orders

### DIFF
--- a/gloss-algorithms/gloss-algorithms.cabal
+++ b/gloss-algorithms/gloss-algorithms.cabal
@@ -1,5 +1,5 @@
 Name:                gloss-algorithms
-Version:             1.9.4.1
+Version:             1.10
 License:             MIT
 License-file:        LICENSE
 Author:              Ben Lippmeier
@@ -25,7 +25,7 @@ Library
         base       == 4.8.*,
         ghc-prim   == 0.4.*,
         containers == 0.5.*,
-        gloss      == 1.9.4.*
+        gloss      == 1.10.*
 
   ghc-options:
         -O2 -Wall

--- a/gloss-examples/gloss-examples.cabal
+++ b/gloss-examples/gloss-examples.cabal
@@ -1,5 +1,5 @@
 Name:                gloss-examples
-Version:             1.9.4.1
+Version:             1.10
 License:             MIT
 License-file:        LICENSE
 Author:              Ben Lippmeier
@@ -32,7 +32,7 @@ Executable gloss-bitmap
         base            == 4.8.*,
         bytestring      == 0.10.*,
         bmp             == 1.2.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is: Main.hs
   hs-source-dirs: picture/Bitmap
   ghc-options:    -threaded -O2
@@ -41,7 +41,7 @@ Executable gloss-bitmap
 Executable gloss-boids
   Build-depends:
         base            == 4.8.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   other-modules:  KDTree2d Vec2
   hs-source-dirs: picture/Boids
@@ -51,7 +51,7 @@ Executable gloss-boids
 Executable gloss-clock
   Build-depends: 
         base            == 4.8.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Clock
   ghc-options:    -threaded -O2
@@ -61,7 +61,7 @@ Executable gloss-color
   Build-depends: 
         base            == 4.8.*,
         vector          == 0.10.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Color
   ghc-options:    -threaded -O2
@@ -72,7 +72,7 @@ Executable gloss-conway
   Build-depends: 
         base            == 4.8.*,
         vector          == 0.10.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   other-modules:  Cell World
   hs-source-dirs: picture/Conway
@@ -82,7 +82,7 @@ Executable gloss-conway
 Executable gloss-draw
   Build-depends:
         base            == 4.8.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Draw
   ghc-options:    -threaded -O2
@@ -91,7 +91,7 @@ Executable gloss-draw
 Executable gloss-easy
   Build-depends:
         base            == 4.8.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Easy
   ghc-options:    -threaded -O2
@@ -101,7 +101,7 @@ Executable gloss-eden
   Build-depends: 
         base            == 4.8.*,
         random          == 1.1.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   other-modules:  Cell Community World
   hs-source-dirs: picture/Eden
@@ -111,7 +111,7 @@ Executable gloss-eden
 Executable gloss-flake
   Build-depends:
         base            == 4.8.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Flake
   ghc-options:    -threaded -O2
@@ -120,7 +120,7 @@ Executable gloss-flake
 Executable gloss-gameevent
   Build-depends: 
         base            == 4.8.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/GameEvent
   ghc-options:    -threaded -O2
@@ -129,7 +129,7 @@ Executable gloss-gameevent
 Executable gloss-hello
   Build-depends: 
         base            == 4.8.*, 
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Hello
   ghc-options:    -threaded -O2
@@ -138,7 +138,7 @@ Executable gloss-hello
 Executable gloss-lifespan
   Build-depends: 
         base            == 4.8.*, 
-        gloss           == 1.9.4.*,
+        gloss           == 1.10.*,
         random          == 1.1.*
   Main-is:        Main.hs
   other-modules:  Cell Community World
@@ -149,7 +149,7 @@ Executable gloss-lifespan
 Executable gloss-machina
   Build-depends: 
         base            == 4.8.*, 
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Machina
   ghc-options:    -threaded -O2
@@ -158,8 +158,8 @@ Executable gloss-machina
 Executable gloss-occlusion
   Build-depends: 
         base             == 4.8.*, 
-        gloss            == 1.9.4.*,
-        gloss-algorithms == 1.9.4.*
+        gloss            == 1.10.*,
+        gloss-algorithms == 1.10.*
   Main-is: Main.hs
   other-modules:  Cell World State Data
   hs-source-dirs: picture/Occlusion
@@ -171,7 +171,7 @@ Executable gloss-styrene
         base            == 4.8.*,
         ghc-prim        == 0.4.*,
         containers      == 0.5.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   other-modules:  Actor Advance Collide Config Contact QuadTree World
   hs-source-dirs: picture/Styrene
@@ -181,7 +181,7 @@ Executable gloss-styrene
 Executable gloss-tree
   Build-depends: 
         base            == 4.8.*, 
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Tree
   ghc-options:    -threaded -O2
@@ -191,7 +191,7 @@ Executable gloss-visibility
   Build-depends: 
         base            == 4.8.*, 
         vector          == 0.10.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   other-modules:  Draw Interface State World Geometry.Randomish Geometry.Segment
   hs-source-dirs: picture/Visibility 
@@ -201,7 +201,7 @@ Executable gloss-visibility
 Executable gloss-zen
   Build-depends: 
         base            == 4.8.*, 
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Zen
   ghc-options:    -threaded -O2
@@ -210,8 +210,8 @@ Executable gloss-zen
 Executable gloss-crystal
   Build-depends:
         base            == 4.8.*,
-        gloss           == 1.9.4.*,
-        gloss-raster    == 1.9.4.*
+        gloss           == 1.10.*,
+        gloss-raster    == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: raster/Crystal
 
@@ -234,8 +234,8 @@ Executable gloss-crystal
 Executable gloss-ray
   Build-depends:
         base           == 4.8.*,
-        gloss          == 1.9.4.*,
-        gloss-raster   == 1.9.4.*
+        gloss          == 1.10.*,
+        gloss-raster   == 1.10.*
   Main-is:        Main.hs
   other-modules:  Light Object Trace Vec3 World
   hs-source-dirs: raster/Ray
@@ -253,8 +253,8 @@ Executable gloss-ray
 Executable gloss-pulse
   Build-depends:
         base           == 4.8.*,
-        gloss          == 1.9.4.*,
-        gloss-raster   == 1.9.4.*
+        gloss          == 1.10.*,
+        gloss-raster   == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: raster/Pulse
   ghc-options:
@@ -273,8 +273,8 @@ Executable gloss-wave
         base           == 4.8.*,
         ghc-prim       == 0.4.*,
         vector         == 0.10.*,
-        gloss          == 1.9.4.*,
-        gloss-raster   == 1.9.4.*
+        gloss          == 1.10.*,
+        gloss-raster   == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: raster/Wave
   ghc-options:
@@ -296,7 +296,7 @@ Executable gloss-fluid
         repa            == 3.4.*,
         repa-io         == 3.4.*,
         repa-algorithms == 3.4.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   other-modules:  
         Args Config FieldElt Model UserEvent
@@ -324,7 +324,7 @@ Executable gloss-snow
   Build-depends:
         base            == 4.8.*,
         repa            == 3.4.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:      Main.hs
   hs-source-dirs: raster/Snow
   ghc-options:
@@ -342,7 +342,7 @@ Executable gloss-mandel
   Build-depends:
         base            == 4.8.*,
         repa            == 3.4.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   other-modules:  Solver
   hs-source-dirs: raster/Mandel
@@ -366,7 +366,7 @@ Executable gloss-graph
   Build-depends:
         base            == 4.8.*,
         containers      == 0.5.*,
-        gloss           == 1.9.4.*
+        gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Graph
   ghc-options:
@@ -377,8 +377,8 @@ Executable gloss-render
   Build-depends:
         base            == 4.8.*,
         containers      == 0.5.*,
-        gloss           == 1.9.4.*,
-        gloss-rendering == 1.9.3.*,
+        gloss           == 1.10.*,
+        gloss-rendering == 1.10.*,
         GLFW-b
   Main-is:        Main.hs
   hs-source-dirs: picture/Render

--- a/gloss-examples/raster/Fluid/src-repa/Model.hs
+++ b/gloss-examples/raster/Fluid/src-repa/Model.hs
@@ -129,6 +129,7 @@ pictureOfModel (scaleX, scaleY) m
 
         let picDens :: G.Picture
             picDens = G.bitmapOfForeignPtr width' height'
+                        (G.BitmapFormat G.BottomToTop G.PxRGBA)
                         (R.toForeignPtr $ unsafeCoerce arrDensity)
                         False
 

--- a/gloss-examples/raster/Mandel/Solver.hs
+++ b/gloss-examples/raster/Mandel/Solver.hs
@@ -102,7 +102,8 @@ makePicture !winSizeX !winSizeY !zoomX !zoomY !makePixel
                 = Scale (fromIntegral zoomX) (fromIntegral zoomY)
                 $ bitmapOfForeignPtr
                         sizeX sizeY     -- raw image size
-                        (R.toForeignPtr $ unsafeCoerce arrRGB)   
+                        (BitmapFormat BottomToTop PxRGBA)
+                        (R.toForeignPtr $ unsafeCoerce arrRGB)
                                         -- the image data.
                         False           -- don't cache this in texture memory.
 

--- a/gloss-raster/Graphics/Gloss/Raster/Array.hs
+++ b/gloss-raster/Graphics/Gloss/Raster/Array.hs
@@ -252,7 +252,8 @@ makeFrame (scaleX, scaleY) !array
                 = Scale (fromIntegral scaleX) (fromIntegral scaleY)
                 $ bitmapOfForeignPtr
                         sizeX sizeY     -- raw image size
-                        (R.toForeignPtr $ unsafeCoerce arrRGB)   
+                        (BitmapFormat BottomToTop PxRGBA)
+                        (R.toForeignPtr $ unsafeCoerce arrRGB)
                                         -- the image data.
                         False           -- don't cache this in texture memory.
 

--- a/gloss-raster/Graphics/Gloss/Raster/Field.hs
+++ b/gloss-raster/Graphics/Gloss/Raster/Field.hs
@@ -205,11 +205,12 @@ makePicture !winSizeX !winSizeY !zoomX !zoomY !makePixel
         traceEventIO "Gloss.Raster[makePicture]: done, returning picture."
 
         -- Wrap the ForeignPtr from the Array as a gloss picture.
-        let picture     
+        let picture
                 = Scale (fromIntegral zoomX) (fromIntegral zoomY)
                 $ bitmapOfForeignPtr
                         sizeX sizeY     -- raw image size
-                        (R.toForeignPtr $ unsafeCoerce arrRGB)   
+                        (BitmapFormat BottomToTop PxRGBA)
+                        (R.toForeignPtr $ unsafeCoerce arrRGB)
                                         -- the image data.
                         False           -- don't cache this in texture memory.
 

--- a/gloss-raster/gloss-raster.cabal
+++ b/gloss-raster/gloss-raster.cabal
@@ -1,5 +1,5 @@
 Name:                gloss-raster
-Version:             1.9.4.1
+Version:             1.10
 License:             MIT
 License-file:        LICENSE
 Author:              Ben Lippmeier
@@ -27,13 +27,13 @@ source-repository head
         location:       https://github.com/benl23x5/gloss
 
 Library
-  Build-Depends: 
+  Build-Depends:
         base            == 4.8.*,
         ghc-prim        == 0.4.*,
         containers      == 0.5.*,
         repa            == 3.4.*,
-        gloss           == 1.9.4.*,
-        gloss-rendering == 1.9.3.*
+        gloss           == 1.10.*,
+        gloss-rendering == 1.10.*
 
   ghc-options:
         -Odph -fno-liberate-case

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/Bitmap.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/Bitmap.hs
@@ -3,7 +3,7 @@
 -- | Helper functions for rendering bitmaps
 module Graphics.Gloss.Internals.Rendering.Bitmap
         ( BitmapData(..)
-        , reverseRGBA
+        , BitmapFormat(..), PixelFormat(..), RowOrder(..)
         , bitmapPath
         , freeBitmapData
         )
@@ -13,11 +13,28 @@ import Foreign
 
 
 -- | Abstract 32-bit RGBA bitmap data.
-data BitmapData 
-        = BitmapData 
-                Int                     -- length (in bytes)
-                (ForeignPtr Word8)      -- pointer to data
-        deriving (Eq, Data, Typeable)
+data BitmapData
+        = BitmapData
+             {  bitmapDataLength :: Int  -- length (in bytes)
+             ,  bitmapFormat     :: BitmapFormat
+             ,  bitmapPointer    :: (ForeignPtr Word8)
+             } deriving (Eq, Data, Typeable)
+
+-- | Description of how the bitmap is layed out in memory.
+--
+-- * Prior version of Gloss assumed `BitmapFormat BottomToTop PxAGBR`
+data BitmapFormat = BitmapFormat { rowOrder    :: RowOrder
+                                 , pixelFormat :: PixelFormat
+                                 } deriving (Eq, Data, Typeable, Show, Ord)
+
+-- |Order of rows in an image are either:
+--
+--   * `TopToBottom` - the top row, followed by the next-lower row and so on.
+--   * `BottomToTop` - the bottom row followed by the next-higher row and so on.
+data RowOrder    = TopToBottom | BottomToTop deriving (Eq, Data, Typeable, Show, Ord, Enum, Bounded)
+
+-- |Pixel formats describe the order of the color channels in memory.
+data PixelFormat = PxRGBA | PxABGR deriving (Eq, Data, Typeable, Show, Ord, Enum, Bounded)
 
 
 instance Show BitmapData where
@@ -26,61 +43,13 @@ instance Show BitmapData where
 
 -- | Generates the point path to display the bitmap centred
 bitmapPath :: Float -> Float -> [(Float, Float)]
-bitmapPath width height 
+bitmapPath width height
  = [(-width', -height'), (width', -height'), (width', height'), (-width', height')]
  where  width'  = width  / 2
         height' = height / 2
 
 
--- | Destructively reverse the byte order in an array.
---   This is necessary as OpenGL reads pixel data as ABGR, rather than RGBA
-reverseRGBA :: BitmapData -> IO ()
-reverseRGBA (BitmapData length8 fptr)
- = withForeignPtr fptr (reverseRGBA_ptr length8)
-
-
--- | Destructively reverses the byte order in an array.
-reverseRGBA_ptr :: Int -> Ptr Word8 -> IO ()
-reverseRGBA_ptr length8 ptr8
- = go (length8 `div` 4) (castPtr ptr8) 0
- where
-        go :: Int -> Ptr Word32 -> Int -> IO ()
-        go len ptr count
-         | count < len 
-         = do   curr <- peekElemOff ptr count
-                let byte0 = shift (isolateByte0 curr) 24
-                let byte1 = shift (isolateByte1 curr) 8
-                let byte2 = shift (isolateByte2 curr) (-8)
-                let byte3 = shift (isolateByte3 curr) (-24)
-                pokeElemOff ptr count (byte0 .|. byte1 .|. byte2 .|. byte3)
-                go len ptr (count + 1)
-
-         | otherwise 
-         = return ()
-
 -- | Frees the allocated memory given to OpenGL to avoid a memory leak
 freeBitmapData :: Ptr Word8 -> IO ()
 {-# INLINE freeBitmapData #-}
 freeBitmapData p = free p
-
-
--- | These functions work as bit masks to isolate the Word8 components
-{-# INLINE isolateByte0 #-}
-isolateByte0 :: Word32 -> Word32
-isolateByte0 word =
-   word .&. (255 :: Word32)
-
-{-# INLINE isolateByte1 #-}
-isolateByte1 :: Word32 -> Word32
-isolateByte1 word =
-   word .&. (65280 :: Word32)
-
-{-# INLINE isolateByte2 #-}
-isolateByte2 :: Word32 -> Word32
-isolateByte2 word =
-   word .&. (16711680 :: Word32)
-
-{-# INLINE isolateByte3 #-}
-isolateByte3 :: Word32 -> Word32
-isolateByte3 word =
-   word .&. (4278190080 :: Word32)

--- a/gloss-rendering/Graphics/Gloss/Rendering.hs
+++ b/gloss-rendering/Graphics/Gloss/Rendering.hs
@@ -15,6 +15,7 @@ module Graphics.Gloss.Rendering
 
           -- * Bitmaps
         , BitmapData
+        , BitmapFormat(..), PixelFormat(..), RowOrder(..)
         , bitmapOfForeignPtr
         , bitmapOfByteString
         , bitmapOfBMP

--- a/gloss-rendering/gloss-rendering.cabal
+++ b/gloss-rendering/gloss-rendering.cabal
@@ -1,5 +1,5 @@
 name:           gloss-rendering
-version:        1.9.3.1
+version:        1.10
 license:        MIT
 license-file:   LICENSE
 author:         Elise Huard

--- a/gloss/Graphics/Gloss/Data/Bitmap.hs
+++ b/gloss/Graphics/Gloss/Data/Bitmap.hs
@@ -1,7 +1,7 @@
 
 -- | Functions to load bitmap data from various places.
 module Graphics.Gloss.Data.Bitmap
-        ( BitmapData
+        ( BitmapData, BitmapFormat(..), RowOrder(..), PixelFormat(..)
         , bitmapOfForeignPtr
         , bitmapOfByteString
         , bitmapOfBMP

--- a/gloss/gloss.cabal
+++ b/gloss/gloss.cabal
@@ -1,5 +1,5 @@
 Name:                gloss
-Version:             1.9.4.1
+Version:             1.10
 License:             MIT
 License-file:        LICENSE
 Author:              Ben Lippmeier
@@ -44,7 +44,7 @@ Library
         OpenGL     == 2.12.*,
         GLUT       == 2.7.*,
         bmp        == 1.2.*,
-        gloss-rendering == 1.9.3.*
+        gloss-rendering == 1.10.*
 
   ghc-options:
         -O2 -Wall


### PR DESCRIPTION
The GL RGBA order (in memory, byte order is A|B|G|R) costs an additional
O(N) memory copy when the source is in the other order.  Instead, we can
expose GL's ABGR order for a performance win.  This change immediatly
allows us to clean up Internals.Rendering.Bitmap (removing the 'reverse'
routine) and positively impacts other packages (ex: gloss-juicy and
friday-juicypixels).

The version bump is due to the change in arguments and type of `bitmapOfForeignPtr`.