### PR TITLE
`stack`-enable `gloss` and `gloss-rendering`

### DIFF
--- a/gloss-rendering/gloss-rendering.cabal
+++ b/gloss-rendering/gloss-rendering.cabal
@@ -31,7 +31,7 @@ library
         base       == 4.8.*,
         containers == 0.5.*,
         bytestring == 0.10.*,
-        OpenGL     == 2.12.*,
+        OpenGL     >= 2.12 && < 3.1,
         GLUT       == 2.7.*,
         bmp        == 1.2.*
 

--- a/gloss-rendering/stack.yaml
+++ b/gloss-rendering/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-5.0

--- a/gloss/gloss.cabal
+++ b/gloss/gloss.cabal
@@ -41,7 +41,7 @@ Library
         ghc-prim   == 0.4.*,
         containers == 0.5.*,
         bytestring == 0.10.*,
-        OpenGL     == 2.12.*,
+        OpenGL     >= 2.12 && < 3.1,
         GLUT       == 2.7.*,
         bmp        == 1.2.*,
         gloss-rendering == 1.10.*

--- a/gloss/stack.yaml
+++ b/gloss/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-5.0
+packages:
+- ../gloss-rendering
+- .


### PR DESCRIPTION
This consists of two changes:

* Increase the upper bound on the `OpenGL` dependency so that `gloss` builds
  against the `lts-5.0` resolver
* Add `stack.yaml` files documenting how to build `gloss`

You can now build both projects by just running `stack build` within either
directory