### PR TITLE
gloss-examples.cabal: allow vector-0.11

### DIFF
--- a/gloss-examples/gloss-examples.cabal
+++ b/gloss-examples/gloss-examples.cabal
@@ -60,7 +60,7 @@ Executable gloss-clock
 Executable gloss-color
   Build-depends: 
         base            == 4.8.*,
-        vector          == 0.10.*,
+        vector          >= 0.10 && < 0.12,
         gloss           == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: picture/Color
@@ -71,7 +71,7 @@ Executable gloss-color
 Executable gloss-conway
   Build-depends: 
         base            == 4.8.*,
-        vector          == 0.10.*,
+        vector          >= 0.10 && < 0.12,
         gloss           == 1.10.*
   Main-is:        Main.hs
   other-modules:  Cell World
@@ -190,7 +190,7 @@ Executable gloss-tree
 Executable gloss-visibility
   Build-depends: 
         base            == 4.8.*, 
-        vector          == 0.10.*,
+        vector          >= 0.10 && < 0.12,
         gloss           == 1.10.*
   Main-is:        Main.hs
   other-modules:  Draw Interface State World Geometry.Randomish Geometry.Segment
@@ -270,11 +270,11 @@ Executable gloss-pulse
 
 Executable gloss-wave
   Build-depends:
-        base           == 4.8.*,
-        ghc-prim       == 0.4.*,
-        vector         == 0.10.*,
-        gloss          == 1.10.*,
-        gloss-raster   == 1.10.*
+        base            == 4.8.*,
+        ghc-prim        == 0.4.*,
+        vector          >= 0.10 && < 0.12,
+        gloss           == 1.10.*,
+        gloss-raster    == 1.10.*
   Main-is:        Main.hs
   hs-source-dirs: raster/Wave
   ghc-options:
@@ -292,7 +292,7 @@ Executable gloss-fluid
   Build-depends:
         base            == 4.8.*,
         ghc-prim        == 0.4.*,
-        vector          == 0.10.*,
+        vector          >= 0.10 && < 0.12,
         repa            == 3.4.*,
         repa-io         == 3.4.*,
         repa-algorithms == 3.4.*,


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich <siarheit@google.com>