### PR TITLE
making gloss compile against the latest glfw

### DIFF
--- a/gloss/Graphics/Gloss/Internals/Interface/Window.hs
+++ b/gloss/Graphics/Gloss/Internals/Interface/Window.hs
@@ -32,7 +32,7 @@ createWindow
         eatBackend
  = do
         -- Turn this on to spew debugging info to stdout
-        let debug       = False
+        let debug       = True -- TODO set this back to False
 
         -- Initialize backend state
         backendStateRef <- newIORef backend

--- a/gloss/gloss.cabal
+++ b/gloss/gloss.cabal
@@ -103,7 +103,8 @@ Library
 
   If flag(GLFW)
     Build-Depends:
-        GLFW-b >= 1.4.1.0 && < 2
+        GLFW-b >= 1.4.1 && < 2,
+        bindings-GLFW >= 3.0
     CPP-Options: -DWITHGLFW
     Other-modules:
         Graphics.Gloss.Internals.Interface.Backend.GLFW


### PR DESCRIPTION
This is a patch that makes gloss compile against the latest GLFW 3.1 bindings. I can make it compile on Windows and create a window, but anything pertaining to drawing within the window seems to crash. I have not tested it on any other OS, and from my debugging it appears to be an issue with my installation. I'm throwing in the towel, but hopefully this patch can be of use instead of rotting on my hard drive.