### PR TITLE
Make compatible with GHC base 4.9

### DIFF
--- a/gloss-rendering/gloss-rendering.cabal
+++ b/gloss-rendering/gloss-rendering.cabal
@@ -28,7 +28,7 @@ library
         Graphics.Gloss.Internals.Rendering.State
 
   build-depends:       
-        base       == 4.8.*,
+        base       >= 4.8 && < 4.10,
         containers == 0.5.*,
         bytestring == 0.10.*,
         OpenGL     >= 2.12 && < 3.1,

--- a/gloss/gloss.cabal
+++ b/gloss/gloss.cabal
@@ -37,8 +37,8 @@ Flag ExplicitBackend
 
 Library
   Build-Depends: 
-        base       == 4.8.*,
-        ghc-prim   == 0.4.*,
+        base       >= 4.8 && < 4.10,
+        ghc-prim   >= 0.4 && < 0.6,
         containers == 0.5.*,
         bytestring == 0.10.*,
         OpenGL     >= 2.12 && < 3.1,


### PR DESCRIPTION
It builds fine without any issues. I also tested it by recompiling and running some of my own programs that use Gloss.