### PR TITLE
Add compatibility with base 4.9

### DIFF
--- a/gloss-algorithms/gloss-algorithms.cabal
+++ b/gloss-algorithms/gloss-algorithms.cabal
@@ -22,8 +22,8 @@ source-repository head
 
 Library
   Build-Depends: 
-        base       == 4.8.*,
-        ghc-prim   == 0.4.*,
+        base       >= 4.8 && < 4.10,
+        ghc-prim   >= 0.4 && < 0.6,
         containers == 0.5.*,
         gloss      == 1.10.*
 

--- a/gloss-rendering/gloss-rendering.cabal
+++ b/gloss-rendering/gloss-rendering.cabal
@@ -28,7 +28,7 @@ library
         Graphics.Gloss.Internals.Rendering.State
 
   build-depends:       
-        base       == 4.8.*,
+        base       >= 4.8 && < 4.10,
         containers == 0.5.*,
         bytestring == 0.10.*,
         OpenGL     >= 2.12 && < 3.1,

--- a/gloss/gloss.cabal
+++ b/gloss/gloss.cabal
@@ -37,8 +37,8 @@ Flag ExplicitBackend
 
 Library
   Build-Depends: 
-        base       == 4.8.*,
-        ghc-prim   == 0.4.*,
+        base       >= 4.8 && < 4.10,
+        ghc-prim   >= 0.4 && < 0.6,
         containers == 0.5.*,
         bytestring == 0.10.*,
         OpenGL     >= 2.12 && < 3.1,


### PR DESCRIPTION
These commits will allow one to build every package except for `gloss-examples` with base 4.9. The examples still work in 4.8 so no functionality is broken, only added.

The reason the examples can't work is because as of yet there seems to be no version of GLFW-b compatible with the new base. However, a version is not forced so without changes to the code it should start working as soon as such an update is released.

In summary:
On 4.8 everything should work the same. On 4.9 you can now use everything except the examples, where previously the build failed.