### PR TITLE
Switch from game mode to fullscreen in GLUT implementation

### DIFF
--- a/gloss/Graphics/Gloss/Internals/Interface/Backend/GLUT.hs
+++ b/gloss/Graphics/Gloss/Internals/Interface/Backend/GLUT.hs
@@ -134,10 +134,12 @@ openWindowGLUT _ display
                           (fromIntegral sizeY)
 
           FullScreen (sizeX, sizeY) -> 
-            do GLUT.gameModeCapabilities $= 
-                 [ GLUT.Where' GLUT.GameModeWidth GLUT.IsEqualTo sizeX
-                 , GLUT.Where' GLUT.GameModeHeight GLUT.IsEqualTo sizeY ]
-               void $ GLUT.enterGameMode
+            do GLUT.initialWindowSize
+                     $= GL.Size
+                          (fromIntegral sizeX)
+                          (fromIntegral sizeY)
+               _ <- GLUT.createWindow "Gloss Application"
+               GLUT.fullScreen
 
         --  Switch some things.
         --  auto repeat interferes with key up / key down checks.


### PR DESCRIPTION
Changes the GLUT `FullScreen` implementation in such a way that the behavior for OSX should stay the same, but significant improvements are made to the behavior on Linux (with freeglut)
For Linux (my setup at least, using freeglut) `FullScreen` would crash except if the size was equal to the actual screen or just `(0,0)`. Something like `(100,100)` would just crash (except if you actually have a 100x100 screen of course). After these changes, it will always create a fullscreen window with a resolution equal to that of the screen. 

The OSX behavior was, and will stay, different from the Linux behavior. However, at least now fullscreen apps that run on one platform should run on the other.

Additional info has been mailed to  benl@ouroborus.net