### PR TITLE
Pull stack.yaml out to top level and add instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Getting something on the screen is as easy as:
     import Graphics.Gloss
     main = display (InWindow "Nice Window" (200, 200) (10, 10)) white (Circle 80)
 
+Explore and run the example projects using [stack](http://haskellstack.org):
+
+    $ stack setup
+    $ stack build
+    $ stack exec gloss-boids
+
 
 Usage
 -----

--- a/gloss-rendering/stack.yaml
+++ b/gloss-rendering/stack.yaml
@@ -1,1 +1,0 @@
-resolver: lts-5.0

--- a/gloss/stack.yaml
+++ b/gloss/stack.yaml
@@ -1,4 +1,0 @@
-resolver: lts-5.0
-packages:
-- ../gloss-rendering
-- .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,38 @@
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-7.16
+
+# Local packages, usually specified by relative directory name
+packages:
+- gloss/
+- gloss-algorithms/
+- gloss-examples/
+- gloss-raster/
+- gloss-rendering/
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor


### PR DESCRIPTION
Some other projects use a single top level stack-file when they have multiple packages like this.

It's easier because when you clone the repo you just type `stack build` and it resolves an environment that will build all of the dependencies and examples all in one go. No need for maintaining multiple stack files or cd-ing into directories.

I also added a note to the front page that prompts the best way to run the example projects, with `gloss-boids` as an example.