### PR TITLE
Blend mode support

### DIFF
--- a/gloss-examples/gloss-examples.cabal
+++ b/gloss-examples/gloss-examples.cabal
@@ -41,7 +41,8 @@ Executable gloss-bitmap
 Executable gloss-boids
   Build-depends:
         base            >= 4.8 && < 4.10,
-        gloss           == 1.10.*
+        gloss           == 1.10.*,
+        OpenGL
   Main-is:        Main.hs
   other-modules:  KDTree2d Vec2
   hs-source-dirs: picture/Boids

--- a/gloss-examples/picture/Boids/Main.hs
+++ b/gloss-examples/picture/Boids/Main.hs
@@ -12,6 +12,9 @@ import Debug.Trace
 import Graphics.Gloss
 import Graphics.Gloss.Interface.Pure.Simulate
 
+-- Temp
+import qualified Graphics.Rendering.OpenGL.GL           as GL
+
 
 -- Parameters -----------------------------------------------------------------
 cParam  = 0.0075
@@ -30,7 +33,7 @@ miny    = -8.0
 
 -- Colors ---------------------------------------------------------------------
 boidColor       = makeColor 1.0 1.0 0.0 1.0
-radiusColor     = makeColor 0.5 1.0 1.0 0.2
+radiusColor     = makeColor 0.5 1.0 1.0 0.3
 cohesionColor   = makeColor 1.0 0.0 0.0 1.0
 separationColor = makeColor 0.0 1.0 0.0 1.0
 alignmentColor  = makeColor 0.0 0.0 1.0 1.0
@@ -118,6 +121,7 @@ renderboid world b
 
         , Color radiusColor $
                 Translate xs ys $
+                --Blend GL.One GL.One $
                 Circle ((realToFrac epsilon) * sf')
 
         , Color boidColor $          

--- a/gloss-rendering/Graphics/Gloss/Internals/Data/Picture.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Data/Picture.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_HADDOCK hide #-}
 {-# OPTIONS -fno-warn-orphans #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 -- | Data types for representing pictures.
 module Graphics.Gloss.Internals.Data.Picture
@@ -17,6 +18,7 @@ module Graphics.Gloss.Internals.Data.Picture
 where
 import Graphics.Gloss.Internals.Data.Color
 import Graphics.Gloss.Internals.Rendering.Bitmap
+import qualified Graphics.Rendering.OpenGL.GL           as GL
 import Codec.BMP
 import Foreign.ForeignPtr
 import Foreign.Marshal.Alloc
@@ -102,7 +104,7 @@ data Picture
         --  than it needs to be.
         --  Setting @True@  for dynamically generated images will cause a
         --  GPU memory leak.
-        | Bitmap        Int     Int     BitmapData Bool
+        | Bitmap        Int     Int     BitmapData      Bool
 
         -- Color ------------------------------------------
         -- | A picture drawn with this color.
@@ -118,6 +120,9 @@ data Picture
         -- | A picture scaled by the given x and y factors.
         | Scale         Float   Float   Picture
 
+        -- | A picture blended using the given blend equation and blend function
+        | Blend         GL.BlendingFactor  GL.BlendingFactor   Picture
+
         -- More Pictures ----------------------------------
         -- | A picture consisting of several others.
         | Pictures      [Picture]
@@ -130,6 +135,8 @@ instance Monoid Picture where
         mappend a b     = Pictures [a, b]
         mconcat         = Pictures
 
+-- Orphan Instances -----------------------------------------------------------
+deriving instance Data GL.BlendingFactor
 
 -- Bitmaps --------------------------------------------------------------------
 -- | O(1). Use a `ForeignPtr` of RGBA data as a bitmap with the given

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/State.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/State.hs
@@ -24,8 +24,8 @@ data State
         -- | Whether to force wireframe mode only
         , stateWireframe        :: !Bool
 
-        -- | Whether to use alpha blending
-        , stateBlendAlpha       :: !Bool
+        -- | Whether to use blending (including alpha blends)
+        , stateBlending         :: !Bool
 
         -- | Whether to use line smoothing
         , stateLineSmooth       :: !Bool
@@ -66,7 +66,7 @@ initState
         return  State
                 { stateColor            = True
                 , stateWireframe        = False
-                , stateBlendAlpha       = True
+                , stateBlending         = True
                 , stateLineSmooth       = False 
                 , stateTextures         = textures }
         


### PR DESCRIPTION
Hi,

I thought I'd put up a (hacky) demo of blend mode support so I can get some feedback on the direction. There are a couple of little pain points -- the big one is having to replicate a lot of data structures in OpenGL with a massive amount of support code if we want to completely decouple. Another is that because of the Data instances, some messy orphan instances are needed.

Anyway, here's what it looks like (uncomment the blend line in `gloss-examples/picture/Boids/Main.hs` and `stack exec gloss-boids`):


<img width="635" alt="screen shot 2017-02-08 at 6 01 33 pm" src="https://cloud.githubusercontent.com/assets/1356959/22726792/67d5c89a-ee29-11e6-9611-9c77f6f28190.png">
