### PR TITLE
Fix FullScreen compatibility issues and add `screensize` getter

### DIFF
--- a/gloss-examples/picture/Gravity/Main.hs
+++ b/gloss-examples/picture/Gravity/Main.hs
@@ -1,0 +1,81 @@
+import Graphics.Gloss
+import System.Random
+
+type Particle = (Float, Float, Float, Float) -- x, y, dx, dy
+
+main :: IO ()
+main = do
+  g <- getStdGen
+  (width,height) <- screensize
+  let initialstate = generateParticles g width height
+  simulate window background fps initialstate render update
+    where
+      window = FullScreen
+      background = black
+      fps = 60
+      render xs =  pictures $ map particleImage xs
+      update _ = updateParticles
+  
+
+-- | Generates particles from StdGen
+generateParticles :: StdGen -> Int -> Int -> [Particle]
+generateParticles gen widthInt heightInt = map (g . f)  tups
+    where
+      f = \(x,y) -> (x * width - width / 2, y * height - height / 2) -- change range [0,1] ->  [-s/2,s/2]
+      g = \(x,y) -> (x,y,0,0) -- add speed of 0
+      tups = take 50 $ zip randoms1 randoms2 -- 200 Random float tuples
+      randoms1 = randoms gen1 :: [Float]
+      randoms2 = randoms gen2 :: [Float]
+      (gen1,gen2) = split gen
+      width = toEnum widthInt
+      height = toEnum heightInt
+
+-- | Particle to its picture
+particleImage :: Particle -> Picture
+particleImage (x,y,_,_) = translate x y $ color white $ circleSolid 2
+
+-- | To update particles for next frame
+updateParticles :: Float -> [Particle] -> [Particle]
+updateParticles dt = (accelerateParticles dt) . (moveParticles dt)
+
+-- | Moves particles based on their speed
+moveParticles :: Float -> [Particle] -> [Particle]
+moveParticles dt = map (\(x,y,dx,dy) -> (x+dx*dt,y+dy*dt,dx,dy))
+
+-- | Accelerates particles based on gravity
+accelerateParticles :: Float -> [Particle] -> [Particle]
+accelerateParticles dt ps = map (gravitate ps dt) ps
+
+-- | Given particles to be gravitating to and for how long, updates a single particle's speed 
+gravitate :: [Particle] -> Float -> Particle -> Particle
+gravitate [] _ p = p
+gravitate ((x',y',_,_):ps) dt p@(x,y,dx,dy) =
+    if separated x x' && separated y y' -- To dodge divByZero or near divByZero anomalies
+    then gravitate ps dt p'
+    else gravitate ps dt p
+        where
+          p' = (x,y,dx+ddx,dy+ddy)
+          ddx = dirx * g
+          ddy = diry * g
+          (dirx,diry) = direction (x,y) (x',y')
+          g = gravitation (x,y) (x',y')
+            
+-- | Normalized vector from one point to another
+direction :: (Float, Float) -> (Float, Float) -> (Float, Float)
+direction (x,y) (x',y') = (dx * scale, dy * scale)
+    where
+      dx = x' - x
+      dy = y' - y
+      scale = 1 / sqrt (dx ^ 2 + dy ^ 2)
+    
+-- | Checks if floats not too close to each other
+separated :: Float -> Float -> Bool
+separated x y = 0.001 < abs (x - y)
+
+-- | Gravitational force of one particle to another
+gravitation :: (Float,Float) -> (Float,Float) -> Float
+gravitation (x,y) (x',y') = g / sqrt (dx ^ 2 + dy ^ 2)
+    where dx = x' - x
+          dy = y' - y
+          g = 1
+

--- a/gloss-examples/raster/Crystal/Main.hs
+++ b/gloss-examples/raster/Crystal/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 
 -- Quasicrystals demo. 
 --  
@@ -5,6 +7,7 @@
 --   http://mainisusuallyafunction.blogspot.com/2011/10/quasicrystals-as-sums-of-waves-in-plane.html
 --
 import Graphics.Gloss.Raster.Field
+import Graphics.Gloss.Util
 import System.Environment
 import System.Exit
 import Data.Char
@@ -16,11 +19,11 @@ main
         config  <- parseArgs args defaultConfig
 
         let display
-             = case configFullScreen config of
-                True  -> FullScreen (configSizeX config, configSizeY config)
-                False -> InWindow "Crystal" 
-                                    (configSizeX config, configSizeY config)
-                                    (10, 10)
+             = if configFullScreen config
+               then FullScreen
+               else InWindow "Crystal"
+                             (configSizeX config, configSizeY config)
+                             (10, 10)
 
         let scale =  fromIntegral $ configScale config
         animateField display
@@ -55,13 +58,9 @@ parseArgs args config
         | []    <- args
         = return config
 
-        | "-fullscreen" : sizeX : sizeY : rest <- args
-        , all isDigit sizeX
-        , all isDigit sizeY
+        | "-fullscreen" : rest <- args
         = parseArgs rest
-        $ config { configSizeX          = read sizeX
-                 , configSizeY          = read sizeY
-                 , configFullScreen     = True }
+        $ config { configFullScreen     = True }
 
         | "-window" : sizeX : sizeY : rest <- args
         , all isDigit sizeX
@@ -90,12 +89,11 @@ parseArgs args config
         = do    printUsage
                 exitWith $ ExitFailure 1
 
-
 printUsage :: IO ()
 printUsage
  = putStr $ unlines
         [ "quazicrystal [flags]"
-        , "    -fullscreen sizeX sizeY  Run full screen"
+        , "    -fullscreen              Run full screen"
         , "    -window     sizeX sizeY  Run in a window                     (default 800, 600)"
         , "    -zoom       <NAT>        Pixel replication factor            (default 5)"
         , "    -scale      <NAT>        Feature size of visualisation       (default 30)"

--- a/gloss-examples/raster/Mandel/Main.hs
+++ b/gloss-examples/raster/Mandel/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns, ScopedTypeVariables #-}
 
 import Graphics.Gloss.Interface.IO.Game
+import Graphics.Gloss.Util
 import Solver
 import Data.Array.Repa.IO.BMP
 import System.Exit
@@ -13,10 +14,15 @@ main :: IO ()
 main 
  = do   args            <- getArgs
         config          <- parseArgs args defaultConfig
+
+        (width,height) <-
+          if configDisplay config == FullScreen
+          then screensize
+          else return (configSizeX config, configSizeY config)
+
         let world       = configPreset config
-                        $ (initWorld (configSizeX config)
-                                     (configSizeY config))
-                          { worldPixelsDynamic = configPixelsDynamic config}
+                          $ (initWorld width height)
+                            { worldPixelsDynamic = configPixelsDynamic config}
 
         case configFileName config of
          -- Run interactively.
@@ -65,13 +71,9 @@ parseArgs args config
         | []    <- args
         = return config
 
-        | "-fullscreen" : sizeX : sizeY : rest <- args
-        , all isDigit sizeX
-        , all isDigit sizeY
+        | "-fullscreen" : rest <- args
         = parseArgs rest 
-        $ config { configDisplay = FullScreen (read sizeX, read sizeY) 
-                 , configSizeX   = read sizeX
-                 , configSizeY   = read sizeY }
+        $ config { configDisplay = FullScreen }
 
         | "-window" : sizeX : sizeY : rest <- args
         , all isDigit sizeX
@@ -104,12 +106,13 @@ parseArgs args config
         = do    printUsage
                 exitWith $ ExitFailure 1
 
+        
 printUsage :: IO ()
 printUsage
  = putStrLn 
         $ unlines
         [ "Usage: gloss-mandel [flags]"
-        , "  -fullscreen  <width::INT> <height::INT>"
+        , "  -fullscreen"
         , "  -window      <width::INT> <height::INT>" 
         , "  -bmp         <width::INT> <height::INT> <FILE>" 
         , "  -dynamic     <INT>   Level of detail reduction when zooming and panning. (4) "

--- a/gloss-raster/Graphics/Gloss/Raster/Array.hs
+++ b/gloss-raster/Graphics/Gloss/Raster/Array.hs
@@ -36,6 +36,7 @@ import Graphics.Gloss.Interface.Pure.Game
 import Graphics.Gloss.Interface.IO.Animate
 import Graphics.Gloss.Interface.IO.Game
 import Graphics.Gloss.Rendering
+import Graphics.Gloss.Util
 import Data.Word
 import System.IO.Unsafe
 import Unsafe.Coerce
@@ -279,10 +280,10 @@ unpackColor c
 {-# INLINE unpackColor #-}
 
 
-sizeOfDisplay :: Display -> (Int, Int)
+sizeOfDisplay :: Display -> IO (Int, Int)
 sizeOfDisplay display
  = case display of
-        InWindow _ s _  -> s
-        FullScreen s    -> s
+        InWindow _ s _  -> return s
+        FullScreen      -> screensize
 {-# INLINE sizeOfDisplay #-}
 

--- a/gloss-raster/Graphics/Gloss/Raster/Field.hs
+++ b/gloss-raster/Graphics/Gloss/Raster/Field.hs
@@ -38,6 +38,7 @@ import Graphics.Gloss.Data.Bitmap
 import Graphics.Gloss.Interface.Pure.Game
 import Graphics.Gloss.Interface.IO.Animate
 import Graphics.Gloss.Rendering
+import Graphics.Gloss.Util
 import Data.Word
 import System.IO.Unsafe
 import Unsafe.Coerce
@@ -111,14 +112,14 @@ animateField display (zoomX, zoomY) makePixel
    then error $ "Graphics.Gloss.Raster.Field: invalid pixel scale factor "
                 P.++ show (zoomX, zoomY)
    else 
-    let (winSizeX, winSizeY) = sizeOfDisplay display
-
-        {-# INLINE frame #-}
-        frame !time
-                = return
+    do (winSizeX, winSizeY) <- sizeOfDisplay display
+       
+       let  frame !time
+              = return
                 $ makePicture winSizeX winSizeY zoomX zoomY (makePixel time)
 
-   in   animateFixedIO display black frame (const $ return ())
+       animateFixedIO display black frame (const $ return ())
+    
 {-# INLINE animateField #-}
 --  INLINE so the repa functions fuse with the users client functions.
 
@@ -147,8 +148,8 @@ playField !display (zoomX, zoomY) !stepRate
    if zoomX < 1 || zoomY < 1
      then  error $ "Graphics.Gloss.Raster.Field: invalid pixel scale factor " 
                  P.++ show (zoomX, zoomY)
-     else  let  (winSizeX, winSizeY) = sizeOfDisplay display
-           in   winSizeX `seq` winSizeY `seq`
+     else  do (winSizeX, winSizeY) <- sizeOfDisplay display
+              winSizeX `seq` winSizeY `seq`
                 play display black stepRate 
                    initWorld
                    (\world -> 
@@ -159,11 +160,11 @@ playField !display (zoomX, zoomY) !stepRate
 {-# INLINE playField #-}
 
 
-sizeOfDisplay :: Display -> (Int, Int)
+sizeOfDisplay :: Display -> IO (Int, Int)
 sizeOfDisplay display
  = case display of
-        InWindow _ s _  -> s
-        FullScreen s    -> s
+        InWindow _ s _  -> return s
+        FullScreen      -> screensize
 {-# INLINE sizeOfDisplay #-}
 
 

--- a/gloss/Graphics/Gloss.hs
+++ b/gloss/Graphics/Gloss.hs
@@ -85,7 +85,8 @@ module Graphics.Gloss
         , display
         , animate
         , simulate
-        , play)
+        , play
+        , screensize)
 where
 import Graphics.Gloss.Data.Display
 import Graphics.Gloss.Data.Picture
@@ -95,3 +96,4 @@ import Graphics.Gloss.Interface.Pure.Display
 import Graphics.Gloss.Interface.Pure.Animate
 import Graphics.Gloss.Interface.Pure.Simulate
 import Graphics.Gloss.Interface.Pure.Game
+import Graphics.Gloss.Util

--- a/gloss/Graphics/Gloss/Data/Display.hs
+++ b/gloss/Graphics/Gloss/Data/Display.hs
@@ -8,6 +8,6 @@ data Display
         -- | Display in a window with the given name, size and position.
         = InWindow   String (Int, Int) (Int, Int)
 
-        -- | Display full screen with a drawing area of the given size.
-        | FullScreen (Int, Int) 
+        -- | Display full screen.
+        | FullScreen
         deriving (Eq, Read, Show)

--- a/gloss/Graphics/Gloss/Internals/Interface/Backend/GLUT.hs
+++ b/gloss/Graphics/Gloss/Internals/Interface/Backend/GLUT.hs
@@ -133,11 +133,9 @@ openWindowGLUT _ display
                           (fromIntegral sizeX)
                           (fromIntegral sizeY)
 
-          FullScreen (sizeX, sizeY) -> 
-            do GLUT.initialWindowSize
-                     $= GL.Size
-                          (fromIntegral sizeX)
-                          (fromIntegral sizeY)
+          FullScreen -> 
+            do size <- get GLUT.screenSize
+               GLUT.initialWindowSize $= size
                _ <- GLUT.createWindow "Gloss Application"
                GLUT.fullScreen
 

--- a/gloss/Graphics/Gloss/Internals/Interface/Backend/GLUT.hs
+++ b/gloss/Graphics/Gloss/Internals/Interface/Backend/GLUT.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_HADDOCK hide #-}
 module Graphics.Gloss.Internals.Interface.Backend.GLUT
-        (GLUTState)
+        (GLUTState,glutStateInit,initializeGLUT)
 where
 
 import Data.IORef
@@ -11,7 +11,17 @@ import qualified Graphics.Rendering.OpenGL as GL
 import qualified Graphics.UI.GLUT               as GLUT
 import qualified System.Exit                    as System
 import Graphics.Gloss.Internals.Interface.Backend.Types
+import System.IO.Unsafe
 
+-- Were we to support freeglut only, we could use GLUT.get to discover
+-- whether we are initialized or not. If not, we do a quick initialize,
+-- get the screenzie, and then do GLUT.exit. This avoids the use of
+-- global variables. Unfortunately, there is no failsafe way to check
+-- whether glut is initialized in some older versions of glut, which is
+-- what we'd use instead of the global variable to get the required info.  
+glutInitialized :: IORef Bool
+{-# NOINLINE glutInitialized #-}
+glutInitialized = unsafePerformIO $ do newIORef False
 
 -- | State information for the GLUT backend.
 data GLUTState 
@@ -31,8 +41,8 @@ data GLUTState
 glutStateInit :: GLUTState
 glutStateInit  
         = GLUTState
-        { glutStateFrameCount   = 0 
-        , glutStateHasTimeout   = False 
+        { glutStateFrameCount   = 0
+        , glutStateHasTimeout   = False
         , glutStateHasIdle      = False }
 
 
@@ -83,25 +93,28 @@ initializeGLUT
         -> IO ()
 
 initializeGLUT _ debug 
- = do   (_progName, _args)  <- GLUT.getArgsAndInitialize
+  = do initialized <- readIORef glutInitialized
+       if not initialized
+         then do  (_progName, _args)  <- GLUT.getArgsAndInitialize
+                  glutVersion         <- get GLUT.glutVersion
+                  when debug
+                    $ putStr  $ "  glutVersion        = " ++ show glutVersion   ++ "\n"
+                  
+                  GLUT.initialDisplayMode
+                    $= [ GLUT.RGBMode
+                       , GLUT.DoubleBuffered]
 
-        glutVersion         <- get GLUT.glutVersion
-        when debug
-         $ putStr  $ "  glutVersion        = " ++ show glutVersion   ++ "\n"
-
-        GLUT.initialDisplayMode
-          $= [ GLUT.RGBMode
-             , GLUT.DoubleBuffered]
-
-        -- See if our requested display mode is possible
-        displayMode         <- get GLUT.initialDisplayMode
-        displayModePossible <- get GLUT.displayModePossible
-        when debug
-         $ do putStr $  "  displayMode        = " ++ show displayMode ++ "\n"
-                     ++ "       possible      = " ++ show displayModePossible ++ "\n"
-                     ++ "\n"
-
-
+                  writeIORef glutInitialized True
+                  
+                  -- See if our requested display mode is possible
+                  displayMode         <- get GLUT.initialDisplayMode
+                  displayModePossible <- get GLUT.displayModePossible
+                  when debug
+                    $ do putStr $  "  displayMode        = " ++ show displayMode ++ "\n"
+                                ++ "       possible      = " ++ show displayModePossible ++ "\n"
+                                ++ "\n"
+         else when debug (putStrLn "Already initialized")
+         
 -- Open Window ----------------------------------------------------------------
 openWindowGLUT
         :: IORef GLUTState

--- a/gloss/Graphics/Gloss/Util.hs
+++ b/gloss/Graphics/Gloss/Util.hs
@@ -1,0 +1,15 @@
+module Graphics.Gloss.Util where
+
+import Graphics.Gloss.Internals.Interface.Backend.GLUT
+
+import qualified Graphics.UI.GLUT as GLUT
+import qualified Graphics.Rendering.OpenGL as GL
+import Data.IORef
+
+-- | Get the size of the screen
+screensize :: IO (Int,Int)
+screensize = do
+  backendStateRef <- newIORef glutStateInit
+  initializeGLUT backendStateRef False
+  GL.Size width height <- GLUT.get GLUT.screenSize
+  return (fromIntegral width, fromIntegral height)

--- a/gloss/gloss.cabal
+++ b/gloss/gloss.cabal
@@ -70,7 +70,8 @@ Library
         Graphics.Gloss.Interface.IO.Display
         Graphics.Gloss.Interface.IO.Simulate
         Graphics.Gloss.Interface.IO.Game
-
+        Graphics.Gloss.Util
+        
   Other-modules:
         Graphics.Gloss.Internals.Color
         Graphics.Gloss.Internals.Interface.Animate.State


### PR DESCRIPTION
# Changes:

The first commit changes the behavior of FullScreen to just be fullscreen. Different system/glut combinations treat the case of having FullScreen with a set size differently; some draw to the specified size and stretch to fullscreen, others ignore the size and just draw to full resolution. This commit makes it such that FullScreen is just fullscreen, so it uses the full resolution as measured by glut, and runs in fullscreen mode. The behavior after this commit seems to be the same on all tested systems (OSX under glut, GNU/Linux under freeglut).

The second commit adds a function to get the screensize. It is screensize :: IO (Int,Int) in Graphics.Gloss.Util. Unfortunately, the desired implementation is not possible with all versions of glut. Thus, except for heavily modifying the way Gloss is used, it seems the best way here would actually be to use a global variable. It's too bad it has to be this way, but it works. The alternative would be to only support freeglut, or to make the user initialize glut himself in some way, but that would at the very least mean that instead of just doing main = play ..., one would have to do something like main = startGloss >> play ... which seems awful to me.

The third commit adapts gloss-raster to the changes made to the behavior of fullscreen. These changes require both the first and second commit, which don't belong together, so including these changes in one of those commits would not be appropriate.

The fourth commit adapts the existing examples to the changes made.

The fifth commit adds an example. The only examples that would have their behavior modified would've been those using gloss-raster. I have added another example which implements the new behavior of FullScreen, but using 'picture mode' rather than raster. This would be a good testcase for further changes to the behavior of FullScreen, as well as the changes in this pull-request itself.

# Further notes:

It would probably be wise to do a major bump to the version of gloss, gloss-examples, and gloss-raster as the behavior of FullScreen is changed in a way that would break older programs that use, or are included in, any of these packages. But I'll leave that judgement to you.
screensize would be adequately documented with the provided comment. FullScreen had it's comment changed in such a way that the documentation should be fine as well.

# Testing

I have run many of the provided examples, including all examples that use FullScreen (Mandel,Crystal, and (newly added) Gravity), on GNU/Linux with freeglut. I have also asked a friend of mine to test these examples on his Mac, running standard glut, and he reports they run fine as well.

Also, my apologies for making new pull-requests all the time.