### PR TITLE
Remove orphan Num instance for pairs

### DIFF
--- a/gloss-examples/picture/Styrene/Advance.hs
+++ b/gloss-examples/picture/Styrene/Advance.hs
@@ -13,6 +13,7 @@ import Graphics.Gloss.Interface.Pure.Simulate
 import Graphics.Gloss.Geometry.Line
 import Graphics.Gloss.Geometry.Angle
 import Graphics.Gloss.Data.Point
+import qualified Graphics.Gloss.Data.Point.Arithmetic as Pt
 import Graphics.Gloss.Data.Vector
 
 import Data.List
@@ -113,8 +114,8 @@ moveActor_free time force actor
                 beadMass        = 1
                 
                 -- calculate the new position and velocity of the bead.
-                pos'            = (pos + time  `mulSV` vel)
-                vel'            = (vel + (time / beadMass) `mulSV` force)
+                pos'            = (pos Pt.+ time  `mulSV` vel)
+                vel'            = (vel Pt.+ (time / beadMass) `mulSV` force)
 
                 -- if the bead is travelling slowly then set it as being stuck.
                 stuck'          

--- a/gloss-examples/picture/Styrene/Collide.hs
+++ b/gloss-examples/picture/Styrene/Collide.hs
@@ -3,6 +3,7 @@ module Collide where
 import World
 import Actor
 import Graphics.Gloss.Data.Point
+import qualified Graphics.Gloss.Data.Point.Arithmetic as Pt
 import Graphics.Gloss.Data.Vector
 import Graphics.Gloss.Geometry.Line
 import Graphics.Gloss.Geometry.Angle
@@ -51,7 +52,7 @@ collideBeadBead_elastic
         mass2   = 1
 
         -- the axis of collision (towards p2)
-        vCollision@(cX, cY)     = normalizeV (p2 - p1)
+        vCollision@(cX, cY)     = normalizeV (p2 Pt.- p1)
         vCollisionR             = (cY, -cX)
         
         -- the velocity component of each bead along the axis of collision
@@ -68,8 +69,8 @@ collideBeadBead_elastic
         k2      = dotV v2 vCollisionR
         
         -- new bead velocities
-        v1'     = mulSV s1' vCollision + mulSV k1 vCollisionR
-        v2'     = mulSV s2' vCollision + mulSV k2 vCollisionR
+        v1'     = mulSV s1' vCollision Pt.+ mulSV k1 vCollisionR
+        v2'     = mulSV s2' vCollision Pt.+ mulSV k2 vCollisionR
 
         v1_slow = mulSV beadBeadLoss v1'
         v2_slow = mulSV beadBeadLoss v2'
@@ -79,11 +80,11 @@ collideBeadBead_elastic
         u2      = r2 / (r1 + r2)
 
         pCollision      
-                = p1 + mulSV u1 (p2 - p1)
+                = p1 Pt.+ mulSV u1 (p2 Pt.- p1)
 
         -- place the beads just next to each other so they are no longer overlapping.
-        p1'     = pCollision - (r1 + 0.001) `mulSV` vCollision
-        p2'     = pCollision + (r2 + 0.001) `mulSV` vCollision
+        p1'     = pCollision Pt.- (r1 + 0.001) `mulSV` vCollision
+        p2'     = pCollision Pt.+ (r2 + 0.001) `mulSV` vCollision
 
         bead1'  = Bead ix1 mode1 r1 p1' v1_slow
         bead2'  = Bead ix2 mode2 r2 p2' v2_slow
@@ -103,7 +104,7 @@ collideBeadBead_static
         -- For beads which have the same radius the collision point is half way between
         -- their centers and u == 0.5
         u               = radius1 / (radius1 + radius2)
-        pCollision      = pBead1 + mulSV u (pBead2 - pBead1)
+        pCollision      = pBead1 Pt.+ mulSV u (pBead2 Pt.- pBead1)
                 
         bead1'          = collideBeadPoint_static
                                 bead1
@@ -126,16 +127,16 @@ collideBeadPoint_static
  = let
         -- take a normal vector from the wall to the bead.
         --      this vector is at a right angle to the wall.
-        vNormal         = normalizeV (pBead - pCollision)
+        vNormal         = normalizeV (pBead Pt.- pCollision)
         
         -- the bead at pBead is overlapping with what it collided with, but we don't want that.
         --      place the bead so it's surface is just next to the point of collision.
-        pBead_new       = pCollision + (radius + 0.01) `mulSV` vNormal
+        pBead_new       = pCollision Pt.+ (radius + 0.01) `mulSV` vNormal
 
         -- work out the angle of incidence for the bounce.
         --      this is the angle between the surface normal and
         --      the direction of travel for the bead.
-        aInc            = angleVV vNormal (negate vIn)
+        aInc            = angleVV vNormal (Pt.negate vIn)
 
         -- aInc2 is the angle between the wall /surface/ and
         --      the direction of travel.

--- a/gloss-rendering/Graphics/Gloss/Internals/Data/Picture.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Data/Picture.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_HADDOCK hide #-}
-{-# OPTIONS -fno-warn-orphans #-}
 
 -- | Data types for representing pictures.
 module Graphics.Gloss.Internals.Data.Picture
@@ -33,22 +32,6 @@ import Prelude hiding (map)
 
 -- | A point on the x-y plane.
 type Point      = (Float, Float)                        
-
-
--- | Pretend a point is a number.
---      Vectors aren't real numbers according to Haskell, because they don't
---      support the multiply and divide field operators. We can pretend they
---      are though, and use the (+) and (-) operators as component-wise
---      addition and subtraction.
---
-instance Num Point where
-        (+) (x1, y1) (x2, y2)   = (x1 + x2, y1 + y2)
-        (-) (x1, y1) (x2, y2)   = (x1 - x2, y1 - y2)
-        (*) (x1, y1) (x2, y2)   = (x1 * x2, y1 * y2)
-        signum (x, y)           = (signum x, signum y)
-        abs    (x, y)           = (abs x, abs y)
-        negate (x, y)           = (negate x, negate y)  
-        fromInteger x           = (fromInteger x, fromInteger x)
 
 
 -- | A vector can be treated as a point, and vis-versa.

--- a/gloss/Graphics/Gloss/Data/Point.hs
+++ b/gloss/Graphics/Gloss/Data/Point.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS -fno-warn-missing-methods -fno-warn-orphans #-}
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
 module Graphics.Gloss.Data.Point
         ( Point, Path
         , pointInBox)

--- a/gloss/Graphics/Gloss/Data/Point/Arithmetic.hs
+++ b/gloss/Graphics/Gloss/Data/Point/Arithmetic.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE BangPatterns #-}
+
+-- |
+-- == Point and vector arithmetic
+--
+-- Vectors aren't numbers according to Haskell, because they don't
+-- support all numeric operations sensibly. We define component-wise
+-- addition, subtraction, and negation along with scalar multiplication
+-- in this module, which is intended to be imported qualified.
+module Graphics.Gloss.Data.Point.Arithmetic
+  (
+    Point
+  , (+)
+  , (-)
+  , (*)
+  , negate
+  ) where
+import Prelude (Float)
+import qualified Prelude as P
+import Graphics.Gloss.Rendering (Point)
+
+infixl 6 +, -
+infixl 7 *
+
+-- | Add two vectors, or add a vector to a point.
+(+) :: Point -> Point -> Point
+(x1, y1) + (x2, y2) =
+  let
+    !x = x1 P.+ x2
+    !y = y1 P.+ y2
+  in (x, y)
+
+-- | Subtract two vectors, or subtract a vector from a point.
+(-) :: Point -> Point -> Point
+(x1, y1) - (x2, y2) =
+  let
+    !x = x1 P.- x2
+    !y = y1 P.- y2
+  in (x, y)
+
+-- | Negate a vector.
+negate :: Point -> Point
+negate (x, y) =
+  let
+    !x' = P.negate x
+    !y' = P.negate y
+  in (x', y')
+
+-- | Multiply a scalar by a vector.
+(*) :: Float -> Point -> Point
+(*) s (x, y) =
+  let
+    !x' = s P.* x
+    !y' = s P.* y
+  in (x', y')

--- a/gloss/Graphics/Gloss/Data/ViewPort.hs
+++ b/gloss/Graphics/Gloss/Data/ViewPort.hs
@@ -6,6 +6,7 @@ module Graphics.Gloss.Data.ViewPort
         , invertViewPort )
 where
 import Graphics.Gloss.Data.Picture
+import qualified Graphics.Gloss.Data.Point.Arithmetic as Pt
 
 
 -- | The 'ViewPort' represents the global transformation applied to the displayed picture.
@@ -51,7 +52,7 @@ invertViewPort
                  , viewPortTranslate    = vtrans
                  , viewPortRotate       = vrotate }
         pos
-        = rotateV (degToRad vrotate) (mulSV (1 / vscale) pos) - vtrans
+        = rotateV (degToRad vrotate) (mulSV (1 / vscale) pos) Pt.- vtrans
 
 
 -- | Convert degrees to radians

--- a/gloss/Graphics/Gloss/Data/ViewState.hs
+++ b/gloss/Graphics/Gloss/Data/ViewState.hs
@@ -17,6 +17,7 @@ import qualified Data.Map                       as Map
 import Data.Map                                 (Map)
 import Data.Maybe
 import Control.Monad (mplus)
+import qualified Graphics.Gloss.Data.Point.Arithmetic as Pt
 
 
 -- | The commands suported by the view controller.
@@ -318,7 +319,7 @@ motionBump
         , viewPortScale         = scale
         , viewPortRotate        = r }
         (bumpX, bumpY)
- = port { viewPortTranslate = trans - o }
+ = port { viewPortTranslate = trans Pt.- o }
  where  offset  = (bumpX / scale, bumpY / scale)
         o       = rotateV (degToRad r) offset
 
@@ -332,7 +333,7 @@ motionTranslate
 motionTranslate Nothing _ _ = Nothing
 motionTranslate (Just (markX, markY)) (posX, posY) viewState
  = Just $ viewState
-        { viewStateViewPort      = port { viewPortTranslate = trans - o }
+        { viewStateViewPort      = port { viewPortTranslate = trans Pt.- o }
         , viewStateTranslateMark = Just (posX, posY) }
 
  where  port    = viewStateViewPort viewState

--- a/gloss/Graphics/Gloss/Geometry/Line.hs
+++ b/gloss/Graphics/Gloss/Geometry/Line.hs
@@ -27,7 +27,7 @@ module Graphics.Gloss.Geometry.Line
 where
 import Graphics.Gloss.Data.Point
 import Graphics.Gloss.Data.Vector
-
+import qualified Graphics.Gloss.Data.Point.Arithmetic as Pt
 
 -- | Check if line segment (P1-P2) clears a box (P3-P4) by being well outside it.
 segClearsBox 
@@ -56,7 +56,7 @@ closestPointOnLine
 {-# INLINE closestPointOnLine #-}
 
 closestPointOnLine p1 p2 p3
-        = p1 + (u `mulSV` (p2 - p1))
+        = p1 Pt.+ (u `mulSV` (p2 Pt.- p1))
         where   u       = closestPointOnLineParam p1 p2 p3
 
 
@@ -89,8 +89,8 @@ closestPointOnLineParam
         -> Float
 
 closestPointOnLineParam p1 p2 p3
-        = (p3 - p1) `dotV` (p2 - p1) 
-        / (p2 - p1) `dotV` (p2 - p1)
+        = (p3 Pt.- p1) `dotV` (p2 Pt.- p1) 
+        / (p2 Pt.- p1) `dotV` (p2 Pt.- p1)
 
 
 

--- a/gloss/gloss.cabal
+++ b/gloss/gloss.cabal
@@ -57,6 +57,7 @@ Library
         Graphics.Gloss.Data.Display
         Graphics.Gloss.Data.Picture
         Graphics.Gloss.Data.Point
+        Graphics.Gloss.Data.Point.Arithmetic
         Graphics.Gloss.Data.Vector
         Graphics.Gloss.Data.ViewPort
         Graphics.Gloss.Data.ViewState


### PR DESCRIPTION
The orphan and largely bogus `Num` instance for pairs infected unrelated code
using `gloss`.

* Remove the `Num` instance for `Point` (pairs of `Float`s).
* Add a module exporting bare-bones vector arithmetic operators. Make
  those operators evaluate their results eagerly to avoid useless
  laziness.

Fixes [Trac 38](http://gloss.ouroborus.net/ticket/38)