### PR TITLE
gloss-raster: Update window size in playField

### DIFF
--- a/gloss-raster/Graphics/Gloss/Raster/Field.hs
+++ b/gloss-raster/Graphics/Gloss/Raster/Field.hs
@@ -153,12 +153,17 @@ playField !display (zoomX, zoomY) !stepRate
      else  do (winSizeX, winSizeY) <- sizeOfDisplay display
               winSizeX `seq` winSizeY `seq`
                 play display black stepRate
-                   initWorld
-                   (\world ->
-                      world `seq`
-                      makePicture winSizeX winSizeY zoomX zoomY (makePixel world))
-                   handleEvent
-                   stepWorld
+                   ((winSizeX, winSizeY), initWorld)
+                   (\((winSizeX', winSizeY'), world) ->
+                      winSizeX' `seq` winSizeY' `seq` world `seq`
+                      makePicture winSizeX' winSizeY' zoomX zoomY (makePixel world))
+                   (\event (winSize, world) ->
+                      let winSize' =
+                            case event of
+                              EventResize dims -> dims
+                              _                -> winSize
+                      in (winSize', handleEvent event world))
+                   (fmap . stepWorld)
 {-# INLINE playField #-}
 
 


### PR DESCRIPTION
The current `playField` uses the initial window sizes and doesn't keep track of subsequent resizes.

This PR makes `playField` keep track of the window size through resizes. This is a similar behaviour to the original `play` function.

*Note*: I have not tested the effect this PR has on the performance of the generated code.