### PR TITLE
gloss:Internals: also clamp negative input values

### DIFF
--- a/gloss-rendering/Graphics/Gloss/Internals/Data/Color.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Data/Color.hs
@@ -112,6 +112,7 @@ rgbaOfColor (RGBA r g b a)      = (r, g, b, a)
 clampColor :: Color -> Color
 clampColor cc
  = let  (r, g, b, a)    = rgbaOfColor cc
-   in   RGBA (min 1 r) (min 1 g) (min 1 b) (min 1 a)
+        clamp x         = (min (max x 0.0) 1.0)
+   in   RGBA (clamp r) (clamp g) (clamp b) (clamp a)
 
 


### PR DESCRIPTION
This pull request so that we also clamp negative color component values.  This might add an extra overhead, but this was mandatory is my case, and the documentation does not explicitly say that only values above 1.0 were 'clamped'.

thank you for this nice library!