### PR TITLE
Resurrect GLFW and fix HiDPI issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .stack-work
 /stack.yaml
 dist
+dist-newstyle
 *.o
 *.hi
 Main

--- a/gloss-examples/picture/Flake/Main.hs
+++ b/gloss-examples/picture/Flake/Main.hs
@@ -1,7 +1,8 @@
-
 -- | Snowflake Fractal.
 --      Based on ANUPlot code by Clem Baker-Finch.
 --
+module Main where
+
 import Graphics.Gloss
 
 main :: IO ()

--- a/gloss-examples/picture/Hello/Main.hs
+++ b/gloss-examples/picture/Hello/Main.hs
@@ -1,6 +1,7 @@
-
 -- | Display "Hello World" in a window.
 --
+module Main where
+
 import Graphics.Gloss
 
 main :: IO ()

--- a/gloss-examples/picture/Tree/Main.hs
+++ b/gloss-examples/picture/Tree/Main.hs
@@ -1,7 +1,8 @@
-
 -- | Tree Fractal.
 --      Based on ANUPlot code by Clem Baker-Finch.
 --
+module Main where
+
 import Graphics.Gloss
 
 main :: IO ()

--- a/gloss-examples/picture/Visibility/Main.hs
+++ b/gloss-examples/picture/Visibility/Main.hs
@@ -1,4 +1,3 @@
-
 -- | Visibility on the 2D plane.
 --   Uses an instance of Warnocks algorithm.
 --   TODO: animate the line segments, make them spin and move around so we can see
@@ -10,6 +9,7 @@
 --  TODO:  To start with just do brute force visibility by dividing field into cells
 --         and doing vis based on center point of cell.
 --
+module Main where
 
 import Interface
 import Draw

--- a/gloss/Graphics/Gloss/Interface/Environment.hs
+++ b/gloss/Graphics/Gloss/Interface/Environment.hs
@@ -1,9 +1,9 @@
 module Graphics.Gloss.Interface.Environment where
-import Graphics.Gloss.Internals.Interface.Backend.GLUT
-import qualified Graphics.UI.GLUT as GLUT
-import qualified Graphics.Rendering.OpenGL as GL
-import Data.IORef
 
+import Data.IORef (newIORef)
+
+import qualified Graphics.Gloss.Internals.Interface.Backend.Types as Backend.Types
+import Graphics.Gloss.Internals.Interface.Backend (defaultBackendState)
 
 -- | Get the size of the screen, in pixels.
 --
@@ -11,9 +11,8 @@ import Data.IORef
 --   fullscreen mode is enabled.
 --
 getScreenSize :: IO (Int, Int)
-getScreenSize
- = do   backendStateRef         <- newIORef glutStateInit
-        initializeGLUT backendStateRef False
-        GL.Size width height    <- GLUT.get GLUT.screenSize
-        return (fromIntegral width, fromIntegral height)
+getScreenSize = do
+       backendStateRef <- newIORef defaultBackendState
+       Backend.Types.initializeBackend backendStateRef False
+       Backend.Types.getScreenSize backendStateRef
 

--- a/gloss/Graphics/Gloss/Internals/Interface/Backend/GLUT.hs
+++ b/gloss/Graphics/Gloss/Internals/Interface/Backend/GLUT.hs
@@ -78,6 +78,10 @@ instance Backend GLUTState where
          = do   GL.Size sizeX sizeY   <- get GLUT.windowSize
                 return (fromEnum sizeX,fromEnum sizeY)
 
+        getScreenSize _
+         = do   GL.Size width height  <- get GLUT.screenSize
+                return (fromIntegral width, fromIntegral height)
+
         elapsedTime _
          = do   t       <- get GLUT.elapsedTime
                 return $ (fromIntegral t) / 1000

--- a/gloss/Graphics/Gloss/Internals/Interface/Backend/Types.hs
+++ b/gloss/Graphics/Gloss/Internals/Interface/Backend/Types.hs
@@ -64,6 +64,9 @@ class Backend a where
         -- | Function that returns (width,height) of the window in pixels.
         getWindowDimensions        :: IORef a -> IO (Int,Int)
 
+        -- | Function that returns (width,height) of a fullscreen window in pixels.
+        getScreenSize              :: IORef a -> IO (Int,Int)
+
         -- | Function that reports the time elapsed since the application started.
         --   (in seconds)
         elapsedTime                :: IORef a -> IO Double

--- a/gloss/gloss.cabal
+++ b/gloss/gloss.cabal
@@ -35,11 +35,6 @@ Flag GLFW
   Description:  Enable the GLFW backend
   Default:      False
 
-Flag ExplicitBackend
-  Description:  Expose versions of 'display' and friends that allow
-                you to choose what window manager backend to use.
-  Default:      False
-
 Library
   Build-Depends:
           base                          >= 4.8 && < 5
@@ -108,11 +103,13 @@ Library
   If flag(GLUT)
     CPP-Options: -DWITHGLUT
     Other-modules:
-        Graphics.Gloss.Internals.Interface.Backend.GLUT
+      Graphics.Gloss.Internals.Interface.Backend.GLUT
 
+  -- NOTE: GLUT is still required for text rendering, and must be initialized
+  --       on Linux platforms. Thus, the GLFW backend still requires GLUT.
   If flag(GLFW)
     Build-Depends:
-        GLFW-b >= 1.4.1.0 && < 2
+      GLFW-b >= 1.4.1.0 && < 2
     CPP-Options: -DWITHGLFW
     Other-modules:
         Graphics.Gloss.Internals.Interface.Backend.GLFW


### PR DESCRIPTION
- Removed `ExplicitBackend` Cabal flag. It didn't do anything. The functionality it was supposed to provide can be added again later if necessary. Backend switching to GLFW can now be accomplished by setting BOTH flags: GLFW -GLUT.

eg:
```
stack build --flag gloss:GLFW --flag gloss:-GLUT
```

- Moved the ability to get the full screen size into the backend. This was previously using GLUT for that purpose, despite a different code path setting the window size when a fullscreen window was finally created by GLFW.

- Fixed the HiDPI issue by setting the OpenGL viewport prior to each drawing call.

- Fixed various issues with existing GLFW backend:
  - Apps would exit immediately because `GLFW.windowShouldClose` was being used incorrectly.
  - OpenGL drawing with GLFW was failing because there was no current context.
  - A lifecycle problem meant that GLFW was still trying to draw after the window had been closed. Now `GLFW.setWindowShouldClose` is used to flag this condition, and `GLFW.terminate` is called at the very end of the main loop as recommended by GLFW.