### PR TITLE
Added "(in degrees)" to the arcSolid and sectorWire comment

### DIFF
--- a/gloss/Graphics/Gloss/Data/Picture.hs
+++ b/gloss/Graphics/Gloss/Data/Picture.hs
@@ -117,14 +117,14 @@ circleSolid r
         = thickCircle (r/2) r
 
 
--- | A solid arc, drawn counter-clockwise between two angles at the given radius.
+-- | A solid arc, drawn counter-clockwise between two angles (in degrees) at the given radius.
 arcSolid  :: Float -> Float -> Float -> Picture
 arcSolid a1 a2 r
         = thickArc a1 a2 (r/2) r
 
 
 -- | A wireframe sector of a circle.
---   An arc is draw counter-clockwise from the first to the second angle at
+--   An arc is draw counter-clockwise from the first to the second angle (in degrees) at
 --   the given radius. Lines are drawn from the origin to the ends of the arc.
 ---
 --   NOTE: We take the absolute value of the radius incase it's negative.


### PR DESCRIPTION
All other comments for arc(...something) clarified that the angles were in degrees. For clarity I added these comments to the remaining comments