### PR TITLE
Render non convex polygons (filled according to parity)

### DIFF
--- a/gloss-algorithms/gloss-algorithms.cabal
+++ b/gloss-algorithms/gloss-algorithms.cabal
@@ -29,7 +29,7 @@ Library
   Build-Depends:
           base                          >= 4.8 && < 5
         , ghc-prim
-        , containers                    >= 0.5 && < 0.7
+        , containers                    >= 0.5 && < 0.8
         , gloss                         == 1.13.*
 
   Default-Language:

--- a/gloss-examples/gloss-examples.cabal
+++ b/gloss-examples/gloss-examples.cabal
@@ -37,7 +37,7 @@ Executable gloss-bitmap
   hs-source-dirs: picture/Bitmap
   Build-depends:
           base                          >= 4.8 && < 5
-        , bytestring                    >= 0.10 && < 0.12
+        , bytestring                    >= 0.10 && < 0.13
         , bmp                           == 1.2.*
         , gloss                         == 1.13.*
 
@@ -98,7 +98,7 @@ Executable gloss-color
   Build-depends:
           base                          >= 4.8 && < 5
         , gloss                         == 1.13.*
-        , vector                        >= 0.11 && < 0.13
+        , vector                        >= 0.11 && < 0.14
 
   Default-Language:
         Haskell2010
@@ -122,7 +122,7 @@ Executable gloss-conway
           base                          >= 4.8 && < 5
         , random                        == 1.2.*
         , gloss                         == 1.13.*
-        , vector                        >= 0.11 && < 0.13
+        , vector                        >= 0.11 && < 0.14
 
   Default-Language:
         Haskell2010
@@ -329,7 +329,7 @@ Executable gloss-styrene
 
   Build-depends:
           base                          >= 4.8 && < 5
-        , containers                    >= 0.5 && < 0.7
+        , containers                    >= 0.5 && < 0.8
         , ghc-prim
         , gloss                         == 1.13.*
 
@@ -376,7 +376,7 @@ Executable gloss-visibility
   Build-depends:
           base                          >= 4.8 && < 5
         , gloss                         == 1.13.*
-        , vector                        >= 0.11 && < 0.13
+        , vector                        >= 0.11 && < 0.14
 
   Default-Language:
         Haskell2010
@@ -514,7 +514,7 @@ Executable gloss-wave
         , ghc-prim
         , gloss                         == 1.13.*
         , gloss-raster                  == 1.13.*
-        , vector                        >= 0.11 && < 0.13
+        , vector                        >= 0.11 && < 0.14
 
   Default-Language:
         Haskell2010
@@ -644,7 +644,7 @@ Executable gloss-graph
 
   Build-depends:
           base                          >= 4.8 && < 5
-        , containers                    >= 0.5 && < 0.7
+        , containers                    >= 0.5 && < 0.8
         , random                        == 1.2.*
         , gloss                         == 1.13.*
 
@@ -664,7 +664,7 @@ Executable gloss-gravity
 
   Build-depends:
           base                          >= 4.8 && < 5
-        , containers                    >= 0.5 && < 0.7
+        , containers                    >= 0.5 && < 0.8
         , random                        == 1.2.*
         , gloss                         == 1.13.*
 

--- a/gloss-raster/gloss-raster.cabal
+++ b/gloss-raster/gloss-raster.cabal
@@ -34,7 +34,7 @@ source-repository this
 Library
   Build-Depends:
           base                          >= 4.8 && < 5
-        , containers                    >= 0.5 && < 0.7
+        , containers                    >= 0.5 && < 0.8
         , ghc-prim
         , gloss                         == 1.13.*
         , gloss-rendering               == 1.13.*

--- a/gloss-rendering/Graphics/Gloss/Internals/Data/Picture.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Data/Picture.hs
@@ -63,7 +63,7 @@ data Picture
         -- | A blank picture, with nothing in it.
         = Blank
 
-        -- | A convex polygon filled with a solid color.
+        -- | A polygon filled with a solid color.
         | Polygon       Path
 
         -- | A line along an arbitrary path.

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/Picture.hs
@@ -7,6 +7,7 @@ where
 import Graphics.Gloss.Internals.Rendering.State
 import Graphics.Gloss.Internals.Rendering.Common
 import Graphics.Gloss.Internals.Rendering.Circle
+import Graphics.Gloss.Internals.Rendering.Polygon
 import Graphics.Gloss.Internals.Rendering.Bitmap
 import Graphics.Gloss.Internals.Data.Picture
 import Graphics.Gloss.Internals.Data.Color
@@ -65,8 +66,7 @@ drawPicture state circScale picture
                 $ vertexPFs path
 
          | otherwise
-         -> GL.renderPrimitive GL.Polygon
-                $ vertexPFs path
+         -> renderComplexPolygon path
 
         -- circle
         Circle radius

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/Polygon.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/Polygon.hs
@@ -10,8 +10,14 @@ renderComplexPolygon :: [(Float,Float)] -> IO ()
 renderComplexPolygon path = do
   Triangulation ts <- triangulate TessWindingOdd 0 ( GL.Normal3 0 0 1) combiner
     (ComplexPolygon [ComplexContour [AnnotatedVertex (GL.Vertex3 (realToFrac a) (realToFrac b) 0) () | (a,b) <- path]])
-  mapM_ renderTriangle ts
+  GL.renderPrimitive GL.Triangles (trisToGLVertices ts)
   return ()
 
-renderTriangle :: Triangle a -> IO ()
-renderTriangle (Triangle (AnnotatedVertex v1 _) (AnnotatedVertex v2 _) (AnnotatedVertex v3 _)) = GL.renderPrimitive GL.Polygon (mapM_ GL.vertex [v1,v2,v3])
+trisToGLVertices ::    [Triangle a] -> IO ()
+trisToGLVertices []    = return ()
+trisToGLVertices ((Triangle (AnnotatedVertex v1 _) (AnnotatedVertex v2 _) (AnnotatedVertex v3 _)) : rest)
+ = do   GL.vertex $ v1
+        GL.vertex $ v2
+        GL.vertex $ v3
+        trisToGLVertices rest
+{-# INLINE trisToGLVertices #-}

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/Polygon.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/Polygon.hs
@@ -1,0 +1,17 @@
+module Graphics.Gloss.Internals.Rendering.Polygon(renderComplexPolygon) where
+import Graphics.Gloss.Internals.Rendering.Common
+import Graphics.Rendering.OpenGL.GLU.Tessellation
+import qualified Graphics.Rendering.OpenGL.GL           as GL
+
+combiner :: a -> b -> ()
+combiner a b = ()
+
+renderComplexPolygon :: [(Float,Float)] -> IO ()
+renderComplexPolygon path = do
+  Triangulation ts <- triangulate TessWindingOdd 0 ( GL.Normal3 0 0 1) combiner
+    (ComplexPolygon [ComplexContour [AnnotatedVertex (GL.Vertex3 (realToFrac a) (realToFrac b) 0) () | (a,b) <- path]])
+  mapM_ renderTriangle ts
+  return ()
+
+renderTriangle :: Triangle a -> IO ()
+renderTriangle (Triangle (AnnotatedVertex v1 _) (AnnotatedVertex v2 _) (AnnotatedVertex v3 _)) = GL.renderPrimitive GL.Polygon (mapM_ GL.vertex [v1,v2,v3])

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/Polygon.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/Polygon.hs
@@ -8,9 +8,16 @@ import qualified Graphics.Rendering.OpenGL.GL           as GL
 combiner :: a -> b -> ()
 combiner _ _ = ()
 
+
+-- written this way to measurably improve performance
+zipLoop :: [a] -> [(a,a)]
+zipLoop [] = []
+zipLoop (x:xs) = go x xs where
+  go y [] = [(y,x)]
+  go y (z:rs) = (y,z) : go z rs
+
 zipWithLoop :: (a->a->b) -> [a] -> [b]
-zipWithLoop _ [] = []
-zipWithLoop f (x:xs) = zipWith f (x:xs) (xs++[x])
+zipWithLoop f = map (uncurry f) . zipLoop
 
 -- signed angle between 2 vectors
 -- https://stackoverflow.com/a/16544330/1779797
@@ -63,5 +70,3 @@ vertexPFs ((x, y) : rest)
  = do   GL.vertex $ GL.Vertex2 (gf x) (gf y)
         vertexPFs rest
 {-# INLINE vertexPFs #-}
-circ :: Float -> [(Float,Float)]
-circ csz = [(100*(sin (i*pi/(csz))), 100*(cos (i*pi/(csz))))  | i <- [1..2*csz]]

--- a/gloss-rendering/Graphics/Gloss/Internals/Rendering/Polygon.hs
+++ b/gloss-rendering/Graphics/Gloss/Internals/Rendering/Polygon.hs
@@ -1,17 +1,51 @@
+{-# OPTIONS_HADDOCK hide #-}
+
 module Graphics.Gloss.Internals.Rendering.Polygon(renderComplexPolygon) where
 import Graphics.Gloss.Internals.Rendering.Common
 import Graphics.Rendering.OpenGL.GLU.Tessellation
 import qualified Graphics.Rendering.OpenGL.GL           as GL
 
 combiner :: a -> b -> ()
-combiner a b = ()
+combiner _ _ = ()
+
+zipWithLoop :: (a->a->b) -> [a] -> [b]
+zipWithLoop _ [] = []
+zipWithLoop f (x:xs) = zipWith f (x:xs) (xs++[x])
+
+-- signed angle between 2 vectors
+-- https://stackoverflow.com/a/16544330/1779797
+-- Note: `isConvex` would remain correct if this returned a value between theta*7/2pi and theta*7/4pi which probably provides an opportunity for optimisation
+angle :: (Float,Float) -> (Float,Float) -> Float
+angle (x1,y1) (x2,y2) = let dot = x1*x2 + y1*y2 -- cos theta * |v1||v2|
+                            det = y2*x1 - x2*y1 -- sin theta * |v1||v2|
+                        in atan2 det dot
+
+
+-- Approximating 2pi by 7 is reasonable here.
+-- The total rotation theoretically must be a multiple of 2pi,
+-- so a little generosity doesn't break anything, but might save some cases that would fail due to floating point errors
+isConvex :: [(Float,Float)] -> Bool
+isConvex ps =
+    -- check that it doesn't turn more than one full circle in total
+    all (\theta -> (theta <= 7) && (theta > -7)) $
+    scanl angleAdd 0 $ -- check that the path's direction is consistent
+    zipWithLoop angle $ -- compute angles of turns at each vertex
+    filter (/= (0,0)) $ -- discard edges arising from duplicated vertices
+    zipWithLoop (\(x1,y1) (x2,y2) -> (x2-x1,y2-y1) ) -- produce vectors for each edge
+        ps
+  where
+    -- Combine angles, but return a value greater than 7 if they have opposite signs
+    angleAdd :: Float -> Float -> Float
+    angleAdd a b = if signum a*signum b < -0.5 then 10 else a + b
 
 renderComplexPolygon :: [(Float,Float)] -> IO ()
-renderComplexPolygon path = do
-  Triangulation ts <- triangulate TessWindingOdd 0 ( GL.Normal3 0 0 1) combiner
-    (ComplexPolygon [ComplexContour [AnnotatedVertex (GL.Vertex3 (realToFrac a) (realToFrac b) 0) () | (a,b) <- path]])
-  GL.renderPrimitive GL.Triangles (trisToGLVertices ts)
-  return ()
+renderComplexPolygon path = if isConvex path
+  then GL.renderPrimitive GL.Polygon $ vertexPFs path
+  else do
+    Triangulation ts <- triangulate TessWindingOdd 0 ( GL.Normal3 0 0 1) combiner
+      (ComplexPolygon [ComplexContour [AnnotatedVertex (GL.Vertex3 (realToFrac a) (realToFrac b) 0) () | (a,b) <- path]])
+    GL.renderPrimitive GL.Triangles (trisToGLVertices ts)
+    return ()
 
 trisToGLVertices ::    [Triangle a] -> IO ()
 trisToGLVertices []    = return ()
@@ -21,3 +55,13 @@ trisToGLVertices ((Triangle (AnnotatedVertex v1 _) (AnnotatedVertex v2 _) (Annot
         GL.vertex $ v3
         trisToGLVertices rest
 {-# INLINE trisToGLVertices #-}
+
+
+vertexPFs ::    [(Float, Float)] -> IO ()
+vertexPFs []    = return ()
+vertexPFs ((x, y) : rest)
+ = do   GL.vertex $ GL.Vertex2 (gf x) (gf y)
+        vertexPFs rest
+{-# INLINE vertexPFs #-}
+circ :: Float -> [(Float,Float)]
+circ csz = [(100*(sin (i*pi/(csz))), 100*(cos (i*pi/(csz))))  | i <- [1..2*csz]]

--- a/gloss-rendering/gloss-rendering.cabal
+++ b/gloss-rendering/gloss-rendering.cabal
@@ -40,8 +40,8 @@ library
   build-depends:
           base                          >= 4.8 && < 5
         , bmp                           == 1.2.*
-        , bytestring                    == 0.11.*
-        , containers                    >= 0.5 && < 0.7
+        , bytestring                    >= 0.11 && < 0.13
+        , containers                    >= 0.5 && < 0.8
         , GLUT                          == 2.7.*
         , OpenGL                        >= 2.12 && < 3.1
 

--- a/gloss-rendering/gloss-rendering.cabal
+++ b/gloss-rendering/gloss-rendering.cabal
@@ -35,6 +35,7 @@ library
         Graphics.Gloss.Internals.Rendering.Common
         Graphics.Gloss.Internals.Rendering.Picture
         Graphics.Gloss.Internals.Rendering.State
+        Graphics.Gloss.Internals.Rendering.Polygon
 
   build-depends:
           base                          >= 4.8 && < 5

--- a/gloss/Graphics/Gloss/Data/Picture.hs
+++ b/gloss/Graphics/Gloss/Data/Picture.hs
@@ -40,7 +40,7 @@ import Graphics.Gloss.Geometry.Angle
 blank :: Picture
 blank   = Blank
 
--- | A convex polygon filled with a solid color.
+-- | A polygon filled with a solid color.
 polygon :: Path -> Picture
 polygon = Polygon
 

--- a/gloss/gloss.cabal
+++ b/gloss/gloss.cabal
@@ -40,8 +40,8 @@ Library
           base                          >= 4.8 && < 5
         , ghc-prim
         , bmp                           == 1.2.*
-        , bytestring                    == 0.11.*
-        , containers                    >= 0.5 && < 0.7
+        , bytestring                    >= 0.11 && < 0.13
+        , containers                    >= 0.5 && < 0.8
         , gloss-rendering               == 1.13.*
         , GLUT                          == 2.7.*
         , OpenGL                        >= 2.12 && < 3.1


### PR DESCRIPTION
This uses GLU's triangulation features (https://hackage.haskell.org/package/OpenGL-3.0.3.0/docs/Graphics-Rendering-OpenGL-GLU-Tessellation.html) to correctly draw non-convex polygons.

This does introduce a significant performance penalty, so it would be reasonable to reject this pull request, or possibly create a new Picture constructor for non-convex polygons.
Testing with a variant of gloss-machina reveals that this slows down rendering a picture consisting entirely of rectangles by a factor at least 4 (something which is closer to the original gloss-machina with transformations and edges is slowed by a factor of 2 due to this PR). When drawing a convex polygon with 100000 vertices, this PR is slows rendering by a factor of around 30 (for self-intersecting polygons, triangulation can increase the number of vertices quadratically, so there's no reasonable comparison without using something like the stencil buffer trick).

There may be performance gains available by calling GLU's tessellator functions more directly.